### PR TITLE
Issue 44

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -113,9 +113,8 @@ object Parser extends Parsers {
             val oneUpdate = parseId ~! EqT() ~! parseExpr ^^ {
                 case f ~ _ ~ e => (ReferenceIdentifier(f._1).setLoc(f), e)
             }
-            LParenT() ~ LBraceT() ~ repsep(oneUpdate, CommaT()) ~
-                RBraceT() ~ RParenT() ^^ {
-                case _ ~ _ ~ updates ~ _ ~ _ => updates
+            LParenT() ~ repsep(oneUpdate, CommaT()) ~ RParenT() ^^ {
+                case _ ~ updates ~ _ => updates
             }
         }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1597,7 +1597,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     decl match {
                         case field: Field => {
                             if (field.name == arg.varName) {
-                                logError(t, ShadowingError(field.name, t.name, field.loc.line))
+                                logError(t, ArgShadowingError(field.name, t.name, field.loc.line))
                             }
                         }
                         case _ => ()

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1547,6 +1547,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             initContext = initContext.updated(arg.varName, arg.typ)
         }
 
+        checkTransactionArgShadowing(startStates, tx)
         checkTransactionInState(tx, lexicallyInsideOf, initContext)
     }
 
@@ -1582,6 +1583,24 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                                 case _ => ()
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    private def checkTransactionArgShadowing(states: Set[StateTable], t: Transaction): Unit = {
+        for (arg <- t.args) {
+            // the possible states the transaction could start in
+            for (state <- states) {
+                for (decl <- state.ast.declarations) {
+                    decl match {
+                        case field: Field => {
+                            if (field.name == arg.varName) {
+                                logError(t, ShadowingError(field.name, t.name, field.loc.line))
+                            }
+                        }
+                        case _ => ()
                     }
                 }
             }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -29,6 +29,11 @@ case class NoMainContractError() extends Error {
 case class ShadowingError(fieldName: String, stateName: String, prevLine: Int) extends Error {
     val msg: String = s"Field '$fieldName' in '$stateName' also declared in contract at line $prevLine. Consider removing declaration in state."
 }
+
+case class ArgShadowingError(arg: String, transactionName: String, prevLine: Int) extends Error {
+    val msg: String = s"The transaction parameter '$arg' in '$transactionName' also declared in contract at line $prevLine. Consider changing the transaction parameter."
+}
+
 case class SharedFieldNameError(fieldName: String, stateName: String, prevLine: Int) extends Error {
     val msg: String = s"Field '$fieldName' previously declared in state '$stateName' at line $prevLine."
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
@@ -184,13 +184,13 @@ class ParserTests extends JUnitSuite {
         shouldSucceed(
             """ main contract C { state S {
               | }
-              | transaction t(T x) available in S { ->S({x = y, y = x}); }
+              | transaction t(T x) available in S { ->S(x = y, y = x); }
               | }
             """.stripMargin)
         shouldSucceed(
             """ main contract C { state S {
               | }
-              | transaction t(T x) available in S { ->S({}); }
+              | transaction t(T x) available in S { ->S(); }
               | }
             """.stripMargin)
         shouldSucceed(
@@ -202,7 +202,7 @@ class ParserTests extends JUnitSuite {
         shouldSucceed(
             """ main contract C { state S {
               | }
-              |  transaction t(T x) available in S { ->S({x = y}); }
+              |  transaction t(T x) available in S { ->S(x = y); }
               | }
             """.stripMargin)
     }


### PR DESCRIPTION
prevent transaction arguments from shadowing field names. 

New method:
checkTransactionArgShadowing, invoked in checkTransaction, takes a set of the possible states the transaction could start in, and the transaction itself. Checks whether any of the arguments of the transaction match any of the state fields. If any do, throws a shadowing error, so now the error message for the given example reads:

At 6.5: Field 'x' in 't' also declared in contract at line 3. Consider removing declaration in state.
