### PR TITLE
Issue 98

### DIFF
--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ChaincodeBaseMock.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ChaincodeBaseMock.java
@@ -280,7 +280,8 @@ public abstract class ChaincodeBaseMock {
     }
 
     // Must be overridden in generated class.
-    public abstract byte[] init(ChaincodeStubMock stub, byte[][] args);
+    public abstract byte[] init(ChaincodeStubMock stub, byte[][] args)
+            throws InvalidProtocolBufferException;
     public abstract byte[] run(ChaincodeStubMock stub, String transactionName, byte[][] args)
             throws InvalidProtocolBufferException, ReentrancyException, BadTransactionException;
     public abstract ChaincodeBaseMock __initFromArchiveBytes(byte[] archiveBytes) throws InvalidProtocolBufferException;

--- a/resources/tests/compilerTests/ConstructorWithArgs.obs
+++ b/resources/tests/compilerTests/ConstructorWithArgs.obs
@@ -1,0 +1,19 @@
+contract A {}
+
+main contract C {
+    int a;
+    A b;
+
+    C(int x, A y) {
+        a = x;
+        b = y;
+        ->S1;
+    }
+
+    state S1 {}
+
+    state S {
+        int x;
+    }
+
+}

--- a/resources/tests/type_checker_tests/MultipleConstructors.obs
+++ b/resources/tests/type_checker_tests/MultipleConstructors.obs
@@ -1,0 +1,14 @@
+main contract C {
+    int x;
+    int y;
+
+    C(int first) {
+        x = first;
+        y = 0;
+    }
+
+    C(int first, int second) {
+        x = first;
+        y = second;
+    }
+}

--- a/resources/tests/type_checker_tests/MultipleConstructors.obs
+++ b/resources/tests/type_checker_tests/MultipleConstructors.obs
@@ -1,3 +1,5 @@
+// testing for main contracts to only have one constructor
+
 main contract C {
     int x;
     int y;
@@ -6,7 +8,7 @@ main contract C {
         x = first;
         y = 0;
     }
-
+    // error: main contracts should have one constructor
     C(int first, int second) {
         x = first;
         y = second;

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -1633,31 +1633,8 @@ class CodeGen (val target: Target) {
 
     /* the local context at the beginning of the method */
 
-    /* The java constructor in the main contract runs every transaction.
-     * The obsidian constructor only runs when the contract is deployed.
+    /* The obsidian constructor only runs when the contract is deployed.
      * Thus, the obsidian constructor must be placed in a distinct method. */
-    private def translateMainConstructor(
-                                            c: Constructor,
-                                            newClass: JDefinedClass,
-                                            translationContext: TranslationContext) : JMethod = {
-        val name = "new_" + newClass.name()
-
-        val meth: JMethod = newClass.method(JMod.PRIVATE, model.VOID, name)
-
-        /* add args to method and collect them in a list */
-        val argList: Seq[(String, JVar)] = c.args.map((arg: VariableDecl) =>
-                (arg.varName, meth.param(resolveType(arg.typ), arg.varName))
-            )
-
-        /* construct the local context from this list */
-        val localContext: immutable.Map[String, JVar] = argList.toMap
-
-        /* add body */
-        translateBody(meth.body(), c.body, translationContext, localContext)
-
-        meth
-    }
-
     private def translateConstructor(
                                         c: Constructor,
                                         newClass: JDefinedClass,

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1760,6 +1760,10 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         if (table.constructors.isEmpty && table.stateLookup.nonEmpty) {
             logError(contract, NoConstructorError(contract.name))
         }
+
+        if (table.constructors.length > 1 && contract.modifiers.contains(IsMain())) {
+            logError(contract, MultipleConstructorsError(contract.name))
+        }
     }
 
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -180,6 +180,10 @@ case class NoConstructorError(contractName: String) extends Error {
     val msg: String = s"Contract '$contractName' must have a constructor since it contains states"
 }
 
+case class MultipleConstructorsError(contractName: String) extends Error {
+    val msg: String = s"Main contract '$contractName' must only contain one constructor."
+}
+
 case class NoParentError(cName: String) extends Error {
     val msg: String = s"Contract $cName has no parent contract"
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/CompilerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/CompilerTests.scala
@@ -48,4 +48,11 @@ class CompilerTests extends JUnitSuite {
     result = Main.compileProgram(inputArgs)
     assertTrue(result)
   }
+
+  @Test def constructorWithArgs(): Unit = {
+    var result = true
+    val inputArgs: Array[String] = Array("--dump-debug", "obs_output", "resources/tests/compilerTests/ConstructorWithArgs.obs")
+    result = Main.compileProgram(inputArgs)
+    assertTrue(result)
+  }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -577,5 +577,13 @@ class TypeCheckerTests extends JUnitSuite {
         )
     }
 
+    @Test def multipleConstructorsTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/MultipleConstructors.obs",
+            (MultipleConstructorsError("C"), 1)
+              ::
+              Nil
+        )
+    }
+
 
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -579,7 +579,7 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def multipleConstructorsTest(): Unit = {
         runTest("resources/tests/type_checker_tests/MultipleConstructors.obs",
-            (MultipleConstructorsError("C"), 1)
+            (MultipleConstructorsError("C"), 3)
               ::
               Nil
         )


### PR DESCRIPTION
To resolve this issue, I had to refactor several things.

In order to properly deserialize the generated code `byte[][] args` in `init` , I needed the types of the arguments to the main contract constructor. To ensure the proper types, the type checker must now enforce that main contracts have only one constructor. Thus, `byte[][] args` should always have the same number of arguments with the same types.

To do this, I added a line in `checkContract` in Checker.scala to check if a main contract had more than one constructor - if so, logged a new `MultipleConstructorsError`. Also added a new typechecker test.

Next, there were two methods in CodeGen.scala, `translateMainConstructor` and `translateConstructor`, which were very similar, so I merged them into a single method `translateConstructor` that now takes a contract to check if it is the main contract. If it is, it adds a private `new_ContractName` method which is used when the main contract is deployed.

Finally, `generateInitMethod` in CodeGen.scala changed in order to deserialize arguments properly. It has to take the types of the arguments, which is determined in `generateMainServerClassMethods` since this is the only call site of `generateInitMethod` . The inherited method from ChaincodeBaseMock.java had to be updated to throw a Protocol Buffer exception. Then I added a check in the generated code that `byte[][] args` has the right length before indexing and deserializing elements of args according to their type.

I also added a compiler test to test this particular case.