### PR TITLE
Issue 101

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -1573,6 +1573,7 @@ class CodeGen (val target: Target) {
                 addArgs(JExpr._new(model.ref(name)), args, translationContext, localContext)
             case Parent() => assert(false, "Parents should not exist in code generation"); JExpr._null()
             case Disown(e) => recurse(e)
+            case OwnershipTransfer(_) => assert(false, "OwnershipTransfer may be removed in the future."); JExpr._null()
             case StateInitializer(stateName, fieldName) => JExpr.ref(stateInitializationVariableName(stateName._1, fieldName._1))
         }
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -1191,7 +1191,7 @@ class CodeGen (val target: Target) {
 
         def handleNonPrimitive(name: String, n: ObsidianType): Unit = {
             // foo = new Foo(); foo.initFromArchive(archive.getFoo());
-            val javaFieldTypeName = javaFieldType.fullName()
+            // val javaFieldTypeName = javaFieldType.fullName()
             val contract = resolveNonPrimitiveTypeToContract(n, translationContext, inContract)
             if (contract.isEmpty) {
                 println("Error: unresolved contract name " + name)
@@ -1242,8 +1242,9 @@ class CodeGen (val target: Target) {
                 val getCall = archive.invoke(getterName)
                 ifNonempty._then().assign(fieldVar, getCall)
             }
-            case n@NonPrimitiveType(unpermissionedType, _) => handleNonPrimitive(field.name, n)
-            case u: UnresolvedNonprimitiveType => assert(false, "Unresolved types should not occur at codegen.")
+            case n: NonPrimitiveType => handleNonPrimitive(field.name, n)
+            case _: InterfaceContractType => assert(false, "Cannot generate field initializer for interface type.")
+            case _: UnresolvedNonprimitiveType => assert(false, "Unresolved types should not occur at codegen.")
             case _: BottomType => assert(false, "Bottom type should not occur at codegen.")
         }
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -1191,7 +1191,6 @@ class CodeGen (val target: Target) {
 
         def handleNonPrimitive(name: String, n: ObsidianType): Unit = {
             // foo = new Foo(); foo.initFromArchive(archive.getFoo());
-            // val javaFieldTypeName = javaFieldType.fullName()
             val contract = resolveNonPrimitiveTypeToContract(n, translationContext, inContract)
             if (contract.isEmpty) {
                 println("Error: unresolved contract name " + name)

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -1203,7 +1203,7 @@ class CodeGen (val target: Target) {
 
                 // TODO
                 /* generate another method that takes the actual archive type
-             * so we don't have to uselessly convert to bytes here */
+                 * so we don't have to uselessly convert to bytes here */
                 body.assign(fieldVar, JExpr._new(javaFieldType))
                 val init = body.invoke(fieldVar, "initFromArchive")
                 init.arg(archive.invoke(getterNameForField(javaFieldName)))

--- a/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
@@ -90,7 +90,8 @@ object ProtobufGen {
             case b@edu.cmu.cs.obsidian.typecheck.BoolType() => ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), f.name)
             case s@edu.cmu.cs.obsidian.typecheck.StringType() => ProtobufField(edu.cmu.cs.obsidian.protobuf.StringType(), f.name)
                 // TODO: get the right type for the state if this is type specifies typestate?
-            case np@NonPrimitiveType(unpermissionedType, mods) => ProtobufField(edu.cmu.cs.obsidian.protobuf.ObjectType(unpermissionedType.toString), f.name)
+            case np@NonPrimitiveType(unpermissionedType, _) => ProtobufField(edu.cmu.cs.obsidian.protobuf.ObjectType(unpermissionedType.toString), f.name)
+            case ict@InterfaceContractType(name, simpleType) => assert(false, "Can't serialize object of interface type."); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
             case BottomType() => assert(false, "Bottom type should not occur at codegen time"); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
             case u@UnresolvedNonprimitiveType(_, _ ) => assert(false, "Unresolved types should not occur at codegen time"); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
         }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
@@ -357,16 +357,17 @@ object AstTransformer {
             case t@BoolType() => (t, List.empty[ErrorRecord])
             case t@IntType() => (t, List.empty[ErrorRecord])
             case t@StringType() => (t, List.empty[ErrorRecord])
-            case nonPrim@UnresolvedNonprimitiveType(mods, ids) =>
+            case nonPrim@UnresolvedNonprimitiveType(_, _) =>
                 val tCanonified: UnresolvedNonprimitiveType = canonifyParsableType(table, context, nonPrim)
                 val result: TraverseResult = resolveNonPrimitiveTypeContext(table, lexicallyInsideOf, tCanonified,
                                                             new TreeSet(), context, pos)
 
                 result match {
                     case Left(err) => (BottomType().setLoc(t), List(ErrorRecord(err, pos)))
-                    case Right((unpermissionedType, declTable)) =>
+                    case Right((unpermissionedType, _)) =>
                         (NonPrimitiveType(unpermissionedType, nonPrim.mods).setLoc(t), List.empty)
                 }
+            case i@InterfaceContractType(_, _) => (i, List.empty)
             case b@BottomType() => (b, List.empty)
             case np: NonPrimitiveType => (np, List.empty)
         }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -30,21 +30,6 @@ case class Context(table: DeclarationTable, underlyingVariableMap: Map[String, O
 
     def apply(s: String): ObsidianType = underlyingVariableMap(s)
 
-    def unresolvedContext: Map[String, PotentiallyUnresolvedType] = {
-        var rawContext = TreeMap[String, PotentiallyUnresolvedType]()
-        for ((x, t) <- underlyingVariableMap) {
-            t match {
-                case BottomType() => ()
-                case u@UnresolvedNonprimitiveType(identifiers, mods) => rawContext = rawContext.updated(x, u)
-                case np@NonPrimitiveType(typ, mods) => rawContext.updated(x, np)
-                case prim@IntType() => rawContext = rawContext.updated(x, prim)
-                case prim@StringType() => rawContext = rawContext.updated(x, prim)
-                case prim@BoolType() => rawContext = rawContext.updated(x, prim)
-            }
-        }
-        rawContext
-    }
-
     def fieldIsInitialized(stateName: String, fieldName: String): Boolean =
         transitionFieldsInitialized.find((e) => e._1 == stateName && e._2 == fieldName).isDefined
 
@@ -468,6 +453,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             val retTypeCalleePoV: UnpermissionedType = astType match {
                 case prim: PrimitiveType => return (prim, contextPrime)
                 case np: NonPrimitiveType => np.extractUnpermissionedType.get
+                case ict: InterfaceContractType => ict.extractUnpermissionedType.get
                 case u: UnresolvedNonprimitiveType =>
                     assert(false); NoPathType(JustContractType("ERROR"))
                 case b: BottomType => assert(false); NoPathType(JustContractType("ERROR"))

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
@@ -172,5 +172,5 @@ case class InterfaceContractType(name: String, simpleType: SimpleType) extends O
     val isBottom: Boolean = false
     override val residualType: ObsidianType = this
     override val extractSimpleType: Option[SimpleType] = Some(simpleType)
-    override val extractUnpermissionedType: Option[UnpermissionedType] = None
+    override val extractUnpermissionedType: Option[UnpermissionedType] = Some(NoPathType(simpleType))
 }


### PR DESCRIPTION
Added `InterfaceContractType` cases to several pattern-matches. Often, it just fails if encountering an interface type, since we don't know how to serialize/deserialize an interface, for instance. But we might add support for interface serialization in the future.

I also added `OwnershipTransfer` to the AST pattern-match block, which asserts false since the syntax for this is going to change.