### PR TITLE
Issue 111

### DIFF
--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/client/ChaincodeClientBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/client/ChaincodeClientBase.java
@@ -11,7 +11,7 @@ import java.net.Socket;
 public abstract class ChaincodeClientBase extends ChaincodeClientStub {
 
     public abstract void invokeClientMain()
-            throws java.io.IOException, ChaincodeClientAbortTransactionException, edu.cmu.cs.obsidian.chaincode.ReentrancyException;
+            throws java.io.IOException, ChaincodeClientAbortTransactionException, edu.cmu.cs.obsidian.chaincode.ReentrancyException, edu.cmu.cs.obsidian.chaincode.BadTransactionException;
 
 
     public void delegatedMain (String args[]) {
@@ -83,6 +83,9 @@ public abstract class ChaincodeClientBase extends ChaincodeClientStub {
         }
         catch (edu.cmu.cs.obsidian.chaincode.ReentrancyException e) {
             System.err.println("Error: Reentrant call made");
+        }
+        catch (edu.cmu.cs.obsidian.chaincode.BadTransactionException e) {
+            System.err.println("Error: call to main failed " + e);
         }
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
@@ -29,7 +29,11 @@ object ProtobufGen {
             // Each import corresponds to a file. Each file has to be read, parsed, and translated into a list of stub contracts.
             val filename = imp.name;
 
-            val ast = Parser.parseFileAtPath(filename, printTokens = false)
+            val parsedAst = Parser.parseFileAtPath(filename, printTokens = false)
+            val table = new SymbolTable(parsedAst)
+            val (globalTable: SymbolTable, transformErrors) = AstTransformer.transformProgram(table)
+            val ast = globalTable.ast
+
             val messages = ast.contracts.map(translateContract)
             (new Protobuf(messages), filename)
         })

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1431,7 +1431,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     case IntType() | BoolType() | StringType() =>
                         logError(s, NonInvokeableError(receiverType))
                         contextPrime
-                    case InterfaceContractType(name, simpleType) =>
+                    case InterfaceContractType(_, simpleType) =>
                         handleInvocation(contextPrime, name, receiver, args, true)
                     case _ =>
                         handleInvocation(contextPrime, name, receiver, args, false)


### PR DESCRIPTION
I was able to resolve the "Unresolved types not allowed at codegen" error by running the ast through the AST transformer in translateImport. I had to do the same in ProtobufGen. I then discovered that the ChaincodeClientBase needed to be updated to throw a BadTransaction exception, which all generated transactions now throw.