### PR TITLE
Issue 19

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -250,7 +250,9 @@ object Main {
                 println()
             }
 
-            val table = new SymbolTable(ast)
+            val importsProcessedAst = ImportProcessor.processImports(filename, ast)
+
+            val table = new SymbolTable(importsProcessedAst)
             val (globalTable: SymbolTable, transformErrors) = AstTransformer.transformProgram(table)
 
             if (options.printAST) {

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -708,12 +708,12 @@ class CodeGen (val target: Target) {
 
         // need to gather the types of the main contract constructor in order to correctly deserialize arguments
         // find the first declaration that is a constructor
-        val constructor: Option[Declaration] = translationContext.contract.declarations.find(decl => decl.isInstanceOf[Constructor])
+        val constructor: Option[Declaration] = translationContext.contract.declarations.find(_.isInstanceOf[Constructor])
         // gather the types of its arguments
         val constructorTypes: Seq[ObsidianType] =
             constructor match {
-                case Some(constr: Constructor) => constr.args.map(a => a.typ)
-                case None => List.empty
+                case Some(constr: Constructor) => constr.args.map(_.typ)
+                case _ => List.empty
             }
 
         /* init method */

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -98,7 +98,7 @@ class CodeGen (val target: Target) {
         }
 
         for (c <- program.contracts) {
-            // TODO : generate code for interfaces
+            // TODO : generate code for interfaces (issue #117)
             if(!c.isInterface) {
                 translateOuterContract(c, programPackage, protobufOuterClassName, contractNameResolutionMap, protobufOuterClassNames)
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -143,6 +143,7 @@ case class Ensures(expr: Expression) extends AST
 sealed abstract trait ContractModifier extends HasLocation
 case class IsResource() extends ContractModifier
 case class IsMain() extends ContractModifier
+case class IsImport() extends ContractModifier
 
 case class Import(name: String) extends AST
 
@@ -154,6 +155,7 @@ case class Contract(modifiers: Set[ContractModifier],
 
     val isResource = modifiers.contains(IsResource())
     val isMain = modifiers.contains(IsMain())
+    val isImport = modifiers.contains(IsImport())
 }
 
 /* Program */

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/ImportProcessor.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/ImportProcessor.scala
@@ -1,0 +1,62 @@
+package edu.cmu.cs.obsidian.parser
+
+object ImportProcessor {
+
+    class ImportException (val message : String) extends Exception {}
+
+    def processImports(name: String, ast: Program): Program = {
+
+        var allContracts = ast.contracts
+
+        ast.imports.foreach(i => {
+            val contracts = processImport(i.name, Seq(Import(name)), ast.contracts.map(_.name))
+
+            contracts match {
+                case Left(msg) => throw new ImportException(msg)
+                case Right(cs) => allContracts = cs ++ allContracts
+            }
+        })
+
+        Program(Seq.empty, allContracts)
+    }
+
+    def processImport(imp: String, seen: Seq[Import], contractNames: Seq[String]) : Either[String, Seq[Contract]] = {
+        val importedProgram = Parser.parseFileAtPath(imp, printTokens = false)
+
+        var contracts = filterTags(importedProgram.contracts)
+
+        importedProgram.contracts.foreach(c => {
+            if (contractNames.contains(c.name)) {
+                return Left("Repeat contract " + c.name + " in " + imp)
+            }
+        })
+
+        val updatedSeen = seen :+ Import(imp)
+        val updatedContractNames = contractNames ++ importedProgram.contracts.map(_.name)
+
+        importedProgram.imports.foreach(i => {
+            if (seen.contains(i)) {
+                return Left("Cyclical import " + i + " from " + imp)
+            }
+
+            val cs = processImport(i.name, updatedSeen, updatedContractNames)
+
+            cs match {
+                case Left(err) => return Left(err)
+                case Right(c) => contracts = c ++ contracts
+
+            }
+        })
+        Right(contracts)
+    }
+
+    // filter out IsMain modifier to ensure only one main contract in Client
+    // add IsImport tag
+    def filterTags(contracts: Seq[Contract]): Seq[Contract] = {
+        contracts.map(c => {
+            val newMods = c.modifiers - IsMain() + IsImport()
+            val newC = Contract(newMods, c.name, c.declarations, c.isInterface)
+            newC
+        })
+    }
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/ImportProcessor.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/ImportProcessor.scala
@@ -20,23 +20,23 @@ object ImportProcessor {
         Program(Seq.empty, allContracts)
     }
 
-    def processImport(imp: String, seen: Seq[Import], contractNames: Seq[String]) : Either[String, Seq[Contract]] = {
-        val importedProgram = Parser.parseFileAtPath(imp, printTokens = false)
+    def processImport(importPath: String, seen: Seq[Import], contractNames: Seq[String]) : Either[String, Seq[Contract]] = {
+        val importedProgram = Parser.parseFileAtPath(importPath, printTokens = false)
 
         var contracts = filterTags(importedProgram.contracts)
 
         importedProgram.contracts.foreach(c => {
             if (contractNames.contains(c.name)) {
-                return Left("Repeat contract " + c.name + " in " + imp)
+                return Left("Repeat contract " + c.name + " in " + importPath)
             }
         })
 
-        val updatedSeen = seen :+ Import(imp)
+        val updatedSeen = seen :+ Import(importPath)
         val updatedContractNames = contractNames ++ importedProgram.contracts.map(_.name)
 
         importedProgram.imports.foreach(i => {
             if (seen.contains(i)) {
-                return Left("Cyclical import " + i + " from " + imp)
+                return Left("Cyclical import " + i + " from " + importPath)
             }
 
             val cs = processImport(i.name, updatedSeen, updatedContractNames)

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
@@ -91,7 +91,7 @@ class StateTable(
 
 class ContractTable(
         val contract: Contract,
-        symbolTable: SymbolTable,
+        var symbolTable: SymbolTable,
         parentContract: Option[ContractTable]) extends DeclarationTable {
     assert (contract != null)
 
@@ -141,11 +141,8 @@ class ContractTable(
                 }
         if (localLookupResult.isDefined) {
             localLookupResult
-        }
-        else {
-            // See if the name is defined in an import.
-            symbolTable.findNameInImports(name)
-        }
+        } // otherwise nothing was found
+        else None
 
     }
 
@@ -177,31 +174,8 @@ class SymbolTable(program: Program) {
         table
     }
 
-    var importContractLookup: Map[String, ContractTable] = {
-        var table = TreeMap[String, ContractTable]()
-
-        for (imp <- ast.imports) {
-            // Each import corresponds to a file. Each file has to be read, parsed, and translated into a list of stub contracts.
-            val filename = imp.name;
-
-            val importAST = Parser.parseFileAtPath(filename, printTokens = false)
-            val importSymbolTable = new SymbolTable(importAST)
-            // This symbol table may include many different contracts. Unpack them.
-            for ((contractName, contractTable) <- importSymbolTable.contractLookup) {
-                if (table.contains(contractName)) {
-                    // TODO: report error for duplicate contract
-                }
-                table = table.updated(contractName, contractTable)
-            }
-        }
-
-        table
-    }
-
     def ast: Program = program
 
     /* only retrieves top level contracts (i.e. not nested) */
     def contract: Function[String, Option[ContractTable]] = contractLookup.get
-
-    def findNameInImports(name: String) : Option[ContractTable] = importContractLookup.get(name)
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
@@ -91,7 +91,7 @@ class StateTable(
 
 class ContractTable(
         val contract: Contract,
-        var symbolTable: SymbolTable,
+        symbolTable: SymbolTable,
         parentContract: Option[ContractTable]) extends DeclarationTable {
     assert (contract != null)
 

--- a/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
@@ -14,33 +14,15 @@ class Unimplemented extends Exception {}
   * Unlike the JCodeModel class hierarchy, this class does code generation in a functional style.
   */
 object ProtobufGen {
-    val UtilitiesPath = "/java-utilities/";
 
     // Programs translate to lists of messages (one per contract).
     def translateProgram(program: Program, sourceFilename: String): Seq[(Protobuf, String)] = {
         val protobuf = new Protobuf(Nil)
-        print(program.imports)
-        val importList = program.imports.filter(!_.name.contains(UtilitiesPath))
-        val protobufs: Seq[(Protobuf, String)] = importList.map ((imp: Import) => {
-            // Each import results in a .proto file, which needs to be compiled.
-            val protobufOuterClassName = Util.protobufOuterClassNameForFilename(imp.name)
-            val protobufFilename = protobufOuterClassName + ".proto"
-
-            // Each import corresponds to a file. Each file has to be read, parsed, and translated into a list of stub contracts.
-            val filename = imp.name;
-
-            val parsedAst = Parser.parseFileAtPath(filename, printTokens = false)
-            val table = new SymbolTable(parsedAst)
-            val (globalTable: SymbolTable, transformErrors) = AstTransformer.transformProgram(table)
-            val ast = globalTable.ast
-
-            val messages = ast.contracts.map(translateContract)
-            (new Protobuf(messages), filename)
-        })
+        assert(program.imports.isEmpty, "Imports should be empty after processing.")
 
         val messages = program.contracts.map(translateContract)
 
-        val result = protobufs :+ ((new Protobuf(messages), sourceFilename))
+        val result: Seq[(Protobuf, String)] = (new Protobuf(messages), sourceFilename) +: Seq.empty
         result
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
@@ -22,7 +22,7 @@ object ProtobufGen {
 
         val messages = program.contracts.map(translateContract)
 
-        val result: Seq[(Protobuf, String)] = (new Protobuf(messages), sourceFilename) +: Seq.empty
+        val result: Seq[(Protobuf, String)] = Seq((new Protobuf(messages), sourceFilename))
         result
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
@@ -23,26 +23,19 @@ object AstTransformer {
     type Context = Map[String, ObsidianType]
     val emptyContext = new TreeMap[String, ObsidianType]()
 
-    private def transformImport(imp: Import): Import = {
-        // TODO
-        imp
-    }
-
     def transformProgram(table: SymbolTable): (SymbolTable, Seq[ErrorRecord]) = {
         var errorRecords = List.empty[ErrorRecord]
         var contracts = List.empty[Contract]
+        assert(table.ast.imports.isEmpty, "Imports should be empty after processing.")
 
-        val imports = table.ast.imports
-        val transformedImports = imports.map(transformImport)
 
         for ((contractName, contractTable) <- table.contractLookup) {
-
             val (newContract, errors) = transformContract(table, contractTable)
             errorRecords = errorRecords ++ errors
             contracts = contracts :+ newContract
         }
 
-        val newProgram = Program(transformedImports, contracts).setLoc(table.ast)
+        val newProgram = Program(Seq.empty, contracts).setLoc(table.ast)
 
         val newTable = new SymbolTable(newProgram)
         (newTable, errorRecords)


### PR DESCRIPTION
In order to support imports in all contracts, I added a stage to code generation for processing imports. At multiple points in code generation, `parseFileAtPath` was called on the imports in the program; however, it is much simpler to parse imports once and add them to the program.

I did this by adding an import processing stage right after parsing and before AST transformation. This allowed me to remove duplicate code from AST transformation, code generation, and protobuf generation, and instead add asserts that program imports are empty after processing. 

In order to properly generate stub contracts, however, I needed to add an `IsImport()` tag to contracts to know which contracts needed stub contracts generated.

ImportProcessor generates a sequence of contracts for each import, keeping track of imports already seen as well as contract names already seen to avoid cyclic imports and name shadowing issues. It recursively gathers contracts from imports from inside other imports as well, and adds the IsImport tag to all of them. 

There was an issue that arose in code generation that there must only be one main contract for building clients, so it removes any IsMain tag from imported contracts. 