### PR TITLE
Unified state union types with single-state types; now all state types can represent unions of states.

### DIFF
--- a/resources/tests/type_checker_tests/Assignment.obs
+++ b/resources/tests/type_checker_tests/Assignment.obs
@@ -12,6 +12,7 @@ main contract C_Shared {
     }
 
     state S { int f2; }
+    state T {}
 }
 
 contract C {

--- a/resources/tests/type_checker_tests/StateInitialization.obs
+++ b/resources/tests/type_checker_tests/StateInitialization.obs
@@ -5,7 +5,6 @@ main contract Test {
     }
 
     state S2 {
-        int x2;
         int x3;
     }
 
@@ -19,7 +18,7 @@ main contract Test {
         S1::shared = 44;
 
         // Error: not transitioning to S2.
-        S2::x2 = 45;
+        S2::x3 = 45;
 
         ->S1;
         ->S3;

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -251,8 +251,9 @@ object Main {
             }
 
             val importsProcessedAst = ImportProcessor.processImports(filename, ast)
+            val fieldsLiftedAst = StateFieldTransformer.transformProgram(importsProcessedAst)
 
-            val table = new SymbolTable(importsProcessedAst)
+            val table = new SymbolTable(fieldsLiftedAst)
             val (globalTable: SymbolTable, transformErrors) = AstTransformer.transformProgram(table)
 
             if (options.printAST) {

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/ImportProcessor.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/ImportProcessor.scala
@@ -17,7 +17,7 @@ object ImportProcessor {
             }
         })
 
-        Program(Seq.empty, allContracts)
+        Program(Seq.empty, allContracts).setLoc(ast)
     }
 
     def processImport(importPath: String, seen: Seq[Import], contractNames: Seq[String]) : Either[String, Seq[Contract]] = {

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/StateFieldTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/StateFieldTransformer.scala
@@ -1,0 +1,46 @@
+package edu.cmu.cs.obsidian.parser
+
+/*
+    The StateFieldProcessor moves all fields that are lexically declared in states into the containing contract
+    with an appropriate "available in" clause.
+ */
+
+object StateFieldTransformer {
+    def transformProgram(p: Program): Program = {
+        val newContracts = p.contracts.map(transformContract)
+
+        p.copy(contracts = newContracts).setLoc(p)
+    }
+
+    def transformContract(contract: Contract): Contract = {
+        val transformedDeclarations = contract.declarations.flatMap((d: Declaration) => transformDeclaration(d))
+        contract.copy(declarations = transformedDeclarations).setLoc(contract)
+    }
+
+
+    def transformDeclaration(decl: Declaration): Seq[Declaration] = {
+        decl match {
+            case s: State => transformState(s)
+            case d: Declaration => Seq(d)
+        }
+    }
+
+    // returns the new state and a sequence of lifted fields.
+    def transformState(state: State): Seq[Declaration] = {
+        val transformedStateFields: Seq[Field] =
+            state.declarations.foldLeft(Seq.empty[Field])((fieldsSoFar: Seq[Field], d: Declaration) =>
+                if (d.isInstanceOf[Field]) {
+                    val f = d.asInstanceOf[Field]
+                    val newField = f.copy(availableIn = Some(Set((state.name, state.loc))))
+                    newField.setLoc(f)
+                    newField +: fieldsSoFar
+                }
+                else {
+                    fieldsSoFar
+                }
+            )
+        val remainingStateDecls = state.declarations.filterNot((d: Declaration) => d.isInstanceOf[Field])
+
+        new State(state.name, remainingStateDecls) +: transformedStateFields
+    }
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
@@ -105,6 +105,8 @@ class ContractTable(
     private var txLookup: Map[String, Transaction] = indexDecl[Transaction](contract.declarations, TransactionDeclTag)
     private var funLookup: Map[String, Func] = indexDecl[Func](contract.declarations, FuncDeclTag)
 
+    val allFields: Set[Field] = fieldLookup.values.toSet
+
     def simpleType = JustContractType(name)
 
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -67,8 +67,7 @@ case class DifferentTypeError(e1: Expression, t1: ObsidianType, e2: Expression, 
 case class FieldUndefinedError(fieldOf: SimpleType, fName: String) extends Error {
     val msg: String = fieldOf match {
         case JustContractType(cName) => s"Field '$fName' is not defined in contract '$cName'"
-        case StateUnionType(cName, _) => s"Field '$fName' is not defined in contract '$cName'"
-        case StateType(cName, sName) => s"Field '$fName' is not defined in state '$sName' of contract '$cName'"
+        case StateType(cName, stateNames) => s"Field '$fName' is not defined in states '$stateNames' of contract '$cName'"
     }
 }
 case class RecursiveFieldTypeError(cName: String, fName: String) extends Error {
@@ -93,10 +92,8 @@ case class MethodUndefinedError(receiver: SimpleType, name: String) extends Erro
     val msg: String = receiver match {
         case JustContractType(cName) =>
             s"No transaction or function with name '$name' was found in contract '$cName'"
-        case StateUnionType(cName, _) =>
-            s"No transaction or function with name '$name' was found in contract '$cName'"
-        case StateType(cName, sName) =>
-            s"No transaction or function with name '$name' was found in state '$sName' of contract '$cName'"
+        case StateType(cName, sNames) =>
+            s"No transaction or function with name '$name' was found in states '$sNames' of contract '$cName'"
     }
 }
 case class StateUndefinedError(cName: String, sName: String) extends Error {
@@ -136,9 +133,10 @@ case class TransitionUpdateError(mustSupply: Set[String]) extends Error {
 case class AssignmentError() extends Error {
     val msg: String = s"Assignment target must be a variable or a field"
 }
-case class AlreadyKnowStateError(e: Expression, sName: String) extends Error {
-    val msg: String = s"'$e' is already known to be in state '$sName': a dynamic check is not needed"
-}
+//case class AlreadyKnowStateError(e: Expression, sName: String) extends Error {
+//    val msg: String = s"'$e' is already known to be in state '$sName': a dynamic check is not needed"
+//}
+
 case class LeakReturnValueError(methName: String) extends Error {
     val msg: String = s"Invocation of '$methName' leaks ownership of return value"
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
@@ -24,15 +24,19 @@ case class JustContractType(contractName: String) extends SimpleType {
 /* Invariant: [stateNames] is missing at least one of the states of the
  * contract (i.e. it is more specific than [JustContractType(contractName)],
  * but has at least 2 distinct states */
-case class StateUnionType(contractName: String, stateNames: Set[String]) extends SimpleType {
+case class StateType(contractName: String, stateNames: Set[String]) extends SimpleType {
+    def this(contractName: String, stateName: String) = {
+        this(contractName, Set(stateName))
+    }
+
     private def orOfStates: String = stateNames.toSeq.tail.foldLeft(stateNames.head)(
         (prev: String, sName: String) => prev + " | " + sName
     )
     override def toString: String = contractName + "." + "(" + orOfStates + ")"
 }
 
-case class StateType(contractName: String, stateName: String) extends SimpleType {
-    override def toString: String = contractName + "." + stateName
+object StateType {
+    def apply(contractName: String, stateName: String): StateType = new StateType(contractName, Set(stateName))
 }
 
 


### PR DESCRIPTION
This is in preparation for re-aligning the type system to the current language design.

I thought initially that the code generator would need changes, but it appears that is not the case.