### PR TITLE
First pass at obstest script. (#73)

### DIFF
--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/client/ChaincodeClientBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/client/ChaincodeClientBase.java
@@ -52,7 +52,7 @@ public abstract class ChaincodeClientBase extends ChaincodeClientStub {
             java.io.InputStreamReader socketReader = new java.io.InputStreamReader(socket.getInputStream());
             JSONWriter jsonWriter = new JSONWriter(socketWriter);
             JSONTokener jsonTokener = new JSONTokener(socket.getInputStream());
-            connectionManager = new ChaincodeClientConnectionManager(socketWriter, socketReader);
+            connectionManager = new ChaincodeClientConnectionManager(socketWriter, socketReader, false);
         }
         catch (java.io.IOException e) {
             System.err.println("Error: failed to connect to " + addressString + ":" + port);

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/client/ChaincodeClientConnectionManager.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/client/ChaincodeClientConnectionManager.java
@@ -15,9 +15,12 @@ public class ChaincodeClientConnectionManager {
     protected Writer underlyingWriter;
     protected Reader underlyingReader;
 
-    public ChaincodeClientConnectionManager(Writer w, Reader r) {
+    private final boolean printDebug;
+
+    public ChaincodeClientConnectionManager(Writer w, Reader r, boolean printDebug) {
         this.underlyingWriter = w;
         this.underlyingReader = r;
+        this.printDebug = printDebug;
     }
 
     public byte[] doTransaction(String transactionName, ArrayList<byte[]> args, boolean returnsNonvoid)
@@ -26,7 +29,7 @@ public class ChaincodeClientConnectionManager {
                 ChaincodeClientTransactionBugException
     {
         JSONWriter jsonWriter = new JSONWriter(underlyingWriter);
-        System.out.println("doTransaction: " + transactionName);
+        if (printDebug) System.out.println("doTransaction: " + transactionName);
         jsonWriter.object(); // outer object for whole message
         jsonWriter.key("jsonrpc");
         jsonWriter.value("2.0");
@@ -59,7 +62,7 @@ public class ChaincodeClientConnectionManager {
 
         JSONTokener jsonTokener = new JSONTokener(underlyingReader);
         Object reply = jsonTokener.nextValue();
-        System.out.println("Received from server: " + reply);
+        if (printDebug) System.out.println("Received from server: " + reply);
 
         if (reply instanceof JSONObject) {
             JSONObject jsonReply = (JSONObject)reply;

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/java-utilities/System.obs
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/java-utilities/System.obs
@@ -1,4 +1,10 @@
 interface System {
      static transaction print(string s);
      static transaction println(string s);
+
+     // TODO: This should be replaced with a more robust system
+     // to print out arbitrary expressions rather than just single
+     // integers.
+     static transaction print(int s);
+     static transaction println(int s);
 }

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ scalaVersion := "2.12.6"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
 
+/* Don't throw TrapExitSecurityException, and return
+ * proper status code when doing "sbt run". */
 trapExit := false
 
 /* testing dependencies */
@@ -25,3 +27,7 @@ assemblyExcludedJars in assembly := {
     }
 }
 
+// don't get confused about multiple META-INF/MANIFEST.MF
+assemblyMergeStrategy in assembly := {
+    case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+}

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ scalaVersion := "2.12.6"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
 
+trapExit := false
+
 /* testing dependencies */
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.1" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/obstest.pl
+++ b/obstest.pl
@@ -134,12 +134,11 @@ sub compile {
                  .qq( --output-path obs_output $file");
     print "$compile\n";
     my $result = `$compile`;
-    print $result if $verbose;
 
-    # I am unsure how to figure out if we succeeded or not -- sbt says 'success' a lot
-    # when it doesn't succeed, and it doesn't seem to do anything w/ return codes.
-    die "sbt did not say 'success':\n$result\n" unless $result =~ /success.+Total time/;
-    die "sbt said 'error':\n$result\n" if $result =~ /error/i;
+    # Make sure the file actually compiled.
+    die "compiler returned exit status $?:\n$result\n" if $? != 0;
+
+    print $result if $verbose;
 }
 
 sub run_test {

--- a/obstest.pl
+++ b/obstest.pl
@@ -48,7 +48,8 @@ sub do_test {
 
     die "Must specify a file to designate as the client.\n" unless exists $servers{client};
 
-    # Since we process client differently, we split it into its own thing.
+    # Since we process client differently, we take its filename out of the general list
+    # of servers and put it into its own variable.
     my $client = $servers{client};
     delete $servers{client};
 
@@ -164,7 +165,6 @@ sub run_test {
         }
     }
 
-    my $output;
     # Wait for the server to start...
     sleep 1;
     # Connect to the server(s)
@@ -175,11 +175,12 @@ sub run_test {
         $cmd .= "localhost $port ";
         $port ++;
     }
+
     print $cmd, "\n";
-    $output = `$cmd`;
+    my $output = `$cmd`;
+
     if ($verbose) {
-        print "Client output:\n";
-        print $output;
+        print "Client output:\n", $output;
     }
 
     kill 'HUP', @pids;

--- a/obstest.pl
+++ b/obstest.pl
@@ -186,12 +186,14 @@ sub run_test {
     print $cmd, "\n";
     my $output = `$cmd`;
 
-    if ($verbose) {
-        print "Client output:\n", $output;
-    }
+    print "Client output:\n", $output if $verbose;
 
     kill 'HUP', @pids;
-    sleep 1; # wait for processes to shut down
+
+    print "Waiting for child processes to shut down.\n" if $verbose;
+
+    # Wait for all child processes to finish.
+    1 while wait() != -1;
 
     return $output;
 }

--- a/obstest.pl
+++ b/obstest.pl
@@ -40,6 +40,9 @@ print "Passed $passed_tests out of $total tests.\n";
 
 if (@failed_tests) {
     print "Failed: ", (join ", ", @failed_tests), "\n";
+    exit 1;
+} else {
+    exit 0;
 }
 
 sub do_test {

--- a/obstest.pl
+++ b/obstest.pl
@@ -1,0 +1,92 @@
+#!/usr/bin/perl
+
+use strict;
+
+for my $filename (@ARGV) {
+    print "$filename\n";
+    eval {
+        run_test($filename);
+    }; if ($@) {
+        print "Error testing $filename: $@";
+    }
+}
+
+sub run_test {
+    my $filename = shift;
+
+    my %properties = parse_obstest($filename);
+
+    # Validate obstest file.
+    die "Must specify Obsidian source file for client.\n" if not exists $properties{client};
+    die "Client source file $properties{client} doesn't exist.\n" if not -e $properties{client};
+    die "Must specify Obsidian source file for server.\n" if not exists $properties{server};
+    die "Server source file $properties{server} doesn't exist.\n" if not -e $properties{server};
+
+    # Compile files
+    compile($properties{server}, '');
+    compile($properties{client}, '--build-client');
+
+    # Use gradle to create a JAR.
+    my $gradlecmd = "gradle -b buildscript/build.gradle -Pmain=$properties{mainclass}";
+    print $gradlecmd, "\n";
+    my $gradleresult = system $gradlecmd;
+
+    die "gradle build failed and returned $gradleresult\n" unless $gradleresult == 0;
+}
+
+sub parse_obstest {
+    my $filename = shift;
+
+    open my $testfile, "<", $filename or die "Cannot open $filename: $!\n";
+
+    # Parse obstest file.
+    my %properties = (expected => '');
+    my @propnames; # remember order properties were declared for when we print them out
+    while (my $line = <$testfile>) {
+        if ($line =~ /(.+): ?(.+)/) {
+            # If the line has a colon in it, parse as a key/value pair.
+            $properties{$1} = $2;
+            push @propnames, $1;
+        } else {
+            # Otherwise, assume it's part of the expected output.
+            $properties{expected} .= $line;
+        }
+    }
+    push @propnames, 'mainclass';
+    push @propnames, 'expected';
+
+    if (not exists $properties{mainclass}) {
+        # You can specify the main class name by adding 'mainclass: <whatever>' to
+        # the obstest file; otherwise, it will use the server file name with
+        # the extension stripped off.
+        $properties{mainclass} = $properties{server};
+        $properties{mainclass} =~ s{\.[^\.]+$}{};
+    }
+
+    # Get path to client and server files relative to testfile.
+    my $dir = $filename;
+    $dir =~ s{/[^/]*$}{/}; # strip off everything following last slash in filename
+    $properties{client} = $dir . $properties{client}; # prepend dir name to source files
+    $properties{server} = $dir . $properties{server};
+
+    for my $k (@propnames) {
+        printf "%10s => $properties{$k}\n", $k;
+    }
+
+    return %properties;
+}
+
+sub compile {
+    # Run obsidian compiler on an .obs file.
+    my ($file, $flags) = @_;
+    my $compile = qq(sbt "run --verbose $flags --dump-debug obs_output)
+                 .qq( --output-path obs_output $file");
+    print "$compile\n";
+    my $result = `$compile`;
+
+    # I am unsure how to figure out if we succeeded or not -- sbt says 'success' a lot
+    # when it doesn't succeed, and it doesn't seem to do anything w/ return codes.
+    die "sbt did not say 'success':\n$result\n" unless $result =~ /success.+Total time/;
+    die "sbt said 'error':\n$result\n" if $result =~ /error/i;
+}
+

--- a/obstest.pl
+++ b/obstest.pl
@@ -66,8 +66,7 @@ sub do_test {
     my $diff = output_diff($output, $props{expected});
 
     if (length $diff > 0) {
-        print $diff;
-        die "Output wasn't what we expected.\n";
+        die "Output wasn't what we expected: $diff";
     }
 }
 

--- a/obstest.pl
+++ b/obstest.pl
@@ -17,6 +17,7 @@ if ($ARGV[0] eq "-v") {
     shift @ARGV;
 }
 
+my @failed_tests;
 my $passed_tests = 0;
 my $total = $#ARGV+1;
 
@@ -28,6 +29,7 @@ for my $filename (@ARGV) {
         do_test($filename);
     }; if ($@) {
         print "Test $filename failed: $@";
+        push @failed_tests, $filename;
     } else {
         print "Test $filename passed!\n";
         $passed_tests ++;
@@ -35,6 +37,10 @@ for my $filename (@ARGV) {
 }
 
 print "Passed $passed_tests out of $total tests.\n";
+
+if (@failed_tests) {
+    print "Failed: ", (join ", ", @failed_tests), "\n";
+}
 
 sub do_test {
     my $filename = shift;
@@ -66,7 +72,7 @@ sub do_test {
     my $diff = output_diff($output, $props{expected});
 
     if (length $diff > 0) {
-        die "Output wasn't what we expected: $diff";
+        die "Output wasn't what we expected:\n$diff\n";
     }
 }
 

--- a/obstest.pl
+++ b/obstest.pl
@@ -5,33 +5,54 @@ use strict;
 for my $filename (@ARGV) {
     print "$filename\n";
     eval {
-        run_test($filename);
+        do_test($filename);
     }; if ($@) {
         print "Error testing $filename: $@";
     }
 }
 
-sub run_test {
+sub do_test {
     my $filename = shift;
 
-    my %properties = parse_obstest($filename);
+    # Parse test file.
+    my ($namesref, $serversref, $propsref) = parse_obstest($filename);
+    my @servernames = @$namesref;
+    my %servers = %$serversref;
+    my %props = %$propsref;
 
-    # Validate obstest file.
-    die "Must specify Obsidian source file for client.\n" if not exists $properties{client};
-    die "Client source file $properties{client} doesn't exist.\n" if not -e $properties{client};
-    die "Must specify Obsidian source file for server.\n" if not exists $properties{server};
-    die "Server source file $properties{server} doesn't exist.\n" if not -e $properties{server};
+    die "Must specify a file to designate as the client.\n" unless exists $servers{client};
+
+    my $client = $servers{client};
+    delete $servers{client};
 
     # Compile files
-    compile($properties{server}, '');
-    compile($properties{client}, '--build-client');
+    compile($client, '--build-client');
+    for my $key (@servernames) {
+        compile($servers{$key}, '');
+    }
 
-    # Use gradle to create a JAR.
-    my $gradlecmd = "gradle -b buildscript/build.gradle -Pmain=$properties{mainclass}";
-    print $gradlecmd, "\n";
-    my $gradleresult = system $gradlecmd;
+    # Run the client and servers and connect them up appropriately.
+    my $output = run_test($client, \@servernames, \%servers);
 
-    die "gradle build failed and returned $gradleresult\n" unless $gradleresult == 0;
+    # Compare expected output to test output.
+    open my $file1, ">", "test-output";
+    print {$file1} $output;
+
+    open my $file2, ">", "expected-output";
+    print {$file2} $props{expected};
+
+    my $diff = `diff test-output expected-output`;
+
+    close $file1;
+    close $file2;
+
+    unlink 'test-output', 'expected-output';
+
+    if (length $diff > 0) {
+        print $diff;
+    } else {
+        print "No difference from expected output!\n";
+    }
 }
 
 sub parse_obstest {
@@ -39,41 +60,46 @@ sub parse_obstest {
 
     open my $testfile, "<", $filename or die "Cannot open $filename: $!\n";
 
-    # Parse obstest file.
-    my %properties = (expected => '');
-    my @propnames; # remember order properties were declared for when we print them out
-    while (my $line = <$testfile>) {
-        if ($line =~ /(.+): ?(.+)/) {
-            # If the line has a colon in it, parse as a key/value pair.
-            $properties{$1} = $2;
-            push @propnames, $1;
-        } else {
-            # Otherwise, assume it's part of the expected output.
-            $properties{expected} .= $line;
-        }
-    }
-    push @propnames, 'mainclass';
-    push @propnames, 'expected';
+    # Parse list of files.
+    my %servers;
+    # Perl hashes are unordered, but order is important here, so we need to
+    # keep track of it ourselves.
+    my @servernames;
 
-    if (not exists $properties{mainclass}) {
-        # You can specify the main class name by adding 'mainclass: <whatever>' to
-        # the obstest file; otherwise, it will use the server file name with
-        # the extension stripped off.
-        $properties{mainclass} = $properties{server};
-        $properties{mainclass} =~ s{\.[^\.]+$}{};
-    }
-
-    # Get path to client and server files relative to testfile.
+    # Get path to obs files relative to testfile.
     my $dir = $filename;
     $dir =~ s{/[^/]*$}{/}; # strip off everything following last slash in filename
-    $properties{client} = $dir . $properties{client}; # prepend dir name to source files
-    $properties{server} = $dir . $properties{server};
-
-    for my $k (@propnames) {
-        printf "%10s => $properties{$k}\n", $k;
+    while (my $line = <$testfile>) {
+        chomp $line;
+        $line =~ s/^ +//;
+        $line =~ s/ +$//;
+        if ($line =~ /(.+): ?(.+)/) {
+            # If the line has a colon in it, parse as a key/value pair.
+            $servers{$1} = $dir . $2;
+            push @servernames, $1 unless $1 eq 'client';
+        } elsif ($line eq '***') {
+            # When we reach a line that's just '***', we break out of this loop
+            # and put everything else as expected output.
+            last;
+        } elsif (length $line > 0) {
+            print "Unable to parse line: $line\n";
+        }
     }
 
-    return %properties;
+    # Special properties we're storing
+    my %props = (expected => '');
+
+    while (my $line = <$testfile>) {
+        # Read the rest of the file.
+        $props{expected} .= $line;
+    }
+
+    for my $k (@servernames) {
+        printf "%10s => %s\n", $k, $servers{$k};
+    }
+    printf "    client => $servers{client}\n";
+
+    return \@servernames, \%servers, \%props;
 }
 
 sub compile {
@@ -90,3 +116,52 @@ sub compile {
     die "sbt said 'error':\n$result\n" if $result =~ /error/i;
 }
 
+sub run_test {
+    my ($client, $namesref, $serversref) = @_;
+    my @servernames = @$namesref;
+    my %servers = %$serversref;
+    # Replace file extensions with '.jar',
+    # and remove preceding directories.
+    my %jars;
+    for my $key (@servernames) {
+        $jars{$key} = $servers{$key};
+        $jars{$key} =~ s{/?([^/]+/)+}{}; # strip leading directories
+        $jars{$key} =~ s{\.[^\.]+$}{.jar}; # change file extension
+    }
+    my $clientjar = $client;
+    $clientjar =~ s{/?([^/]+/)+}{};
+    $clientjar =~ s{\.[^\.]+$}{.jar};
+
+    # Fork a new process to run each non-client file.
+    my @pids;
+    my $port = 5566;
+    for my $key (@servernames) {
+        if (my $child = fork) {
+            push @pids, $child;
+            $port ++;
+        } else {
+            # Start the server
+            print("java -jar $jars{$key} localhost $port\n");
+            exec('java', '-jar', $jars{$key}, 'localhost', $port);
+        }
+    }
+
+    my $output;
+    # Wait for the server to start...
+    sleep 1;
+    # Connect to the server(s)
+    $port = 5566;
+    my $cmd = "java -jar $clientjar ";
+    for my $key (@servernames) {
+        # Pass the port of each server file to the client.
+        $cmd .= "localhost $port ";
+        $port ++;
+    }
+    print $cmd, "\n";
+    $output = `$cmd`;
+
+    kill 'HUP', @pids;
+    sleep 1; # wait for processes to shut down
+
+    return $output;
+}

--- a/resources/tests/IntContainerClient.obs
+++ b/resources/tests/IntContainerClient.obs
@@ -1,8 +1,11 @@
 import "resources/tests/IntContainer.obs"
+import "Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/java-utilities/System.obs"
 
 main contract IntContainerClient {
     transaction main(remote IntContainer container) {
         int oldX = container.setX(3);
-        container.setX(4);
+        System.println(oldX);
+        oldX = container.setX(4);
+        System.println(oldX);
     }
 }

--- a/resources/tests/TestIntContainer.obstest
+++ b/resources/tests/TestIntContainer.obstest
@@ -1,7 +1,5 @@
 server: IntContainer.obs
 client: IntContainerClient.obs
 ***
-doTransaction: setX
-Received from server: {"result":{"message":"BA==","status":"OK"}}
-doTransaction: setX
-Received from server: {"result":{"message":"Aw==","status":"OK"}}
+4
+3

--- a/resources/tests/TestIntContainer.obstest
+++ b/resources/tests/TestIntContainer.obstest
@@ -1,2 +1,7 @@
 server: IntContainer.obs
 client: IntContainerClient.obs
+***
+doTransaction: setX
+Received from server: {"result":{"message":"BA==","status":"OK"}}
+doTransaction: setX
+Received from server: {"result":{"message":"Aw==","status":"OK"}}

--- a/resources/tests/TestIntContainer.obstest
+++ b/resources/tests/TestIntContainer.obstest
@@ -1,0 +1,2 @@
+server: IntContainer.obs
+client: IntContainerClient.obs


### PR DESCRIPTION
This script reads in `.obstest` files which are specified like this:
```
server1: file1.obs
server2: file2.obs
client: client.obs
***
expected output
```
It locates these files relative to the location of the obstest script, then compiles each of the files, compiling the `client` contract with the `--build-client` flag. It forks off processes to run each non-client 
process on a different port, then passes each one to the client (on the command line, for now), and checks that the output of the client matches what's specified in the file using `diff`.

It's written in Perl. I think it was easier than trying to parse text files using bash...

This is just a first pass at this script -- it might want to support changing the port number, and it doesn't yet support running these things on the actual blockchain. Also, the client doesn't actually handle receiving more than one server yet.

(Also, it's not very good at figuring out whether compilation failed. I'm not sure if that's SBT or the Obsidian compiler's fault, but if we could get a success/failure return code, that would be great.)