### PR TITLE
Return more meaningful exit codes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,10 @@ scalaVersion := "2.12.6"
 
 libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.6"
 
+/* Allow passing return code through SBT without
+ * SBT throwing an exception. */
+trapExit := false
+
 /* testing dependencies */
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.1" % "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -73,7 +73,7 @@ object Main {
                 case option :: tail =>
                     if (option.startsWith("--") || option.startsWith("-")) {
                         println("Unknown option " + option)
-                        sys.exit(0)
+                        sys.exit(2)
                     }
                     else if (option.endsWith(".obs")) {
                         // This is an input file.
@@ -82,7 +82,7 @@ object Main {
                     }
                     else {
                         println("Unknown argument " + option)
-                        sys.exit(0)
+                        sys.exit(2)
                     }
             }
         }
@@ -91,11 +91,12 @@ object Main {
 
         if (inputFiles.isEmpty) {
             println("Must pass at least one file")
-            sys.exit(0)
+            sys.exit(2)
         }
 
         if (inputFiles.length > 1) {
             println("For now: contracts can only consist of a single file")
+            sys.exit(2)
         }
 
         CompilerOptions(outputPath, debugPath, inputFiles, verbose, checkerDebug,
@@ -205,7 +206,12 @@ object Main {
             println(usage)
             sys.exit(0)
         }
-        compileProgram(args)
+        val compileSuccess = compileProgram(args)
+        if (compileSuccess) {
+            sys.exit(0)
+        } else {
+            sys.exit(1)
+        }
     }
     def compileProgram(args: Array[String]): Boolean = {
         val options = parseOptions(args.toList)

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -206,8 +206,7 @@ object Main {
             println(usage)
             sys.exit(0)
         }
-        val compileSuccess = compileProgram(args)
-        if (compileSuccess) {
+        if (compileProgram(args)) {
             sys.exit(0)
         } else {
             sys.exit(1)

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -201,6 +201,8 @@ object Main {
 
     // For input foo.obs, we generate foo.proto, from which we generate FooOuterClass.java.
     //    We also generate a jar at the specified directory, containing the generated classes.
+    // The compiler returns an exit status of 0 if everything went well, 1 if there was an error
+    //    compiling the contract, or 2 if it failed to parse the command-line options.
     def main(args: Array[String]): Unit = {
         if (args.length == 0) {
             println(usage)


### PR DESCRIPTION
Fixes #123 by having the compiler return `2` when there was an error parsing arguments, and `1` when there was an error compiling the program. This will make it easier for us to test whether or not compilation succeeded.