### PR TITLE
Fix state transition issue

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -1796,7 +1796,8 @@ class CodeGen (val target: Target) {
                 updates match {
                     case Some(u) =>
                         for ((f, e) <- u) {
-                            body.assign(newStField.ref(f.name), translateExpr(e, translationContext, localContext))
+                            assignVariable(f.name, translateExpr(e, translationContext, localContext),
+                                body, translationContext, localContext)
                         }
                     case None =>
                         // Fields should have been initialized individually, via S1::foo = bar.


### PR DESCRIPTION
When state fields were pulled to the top level, an issue arose in code generation where the code still referenced the fields inside the inner class. This error arose during state transitions, so I changed it from referring to the (non existent) state fields to assigning the top level field.

Example error:
`obs_output/generated_java/edu/cmu/cs/obsidian/generated_code/Bid.java:21: error: cannot find symbol
        __stateAvailable.timeAvailable = expirationDate;
                        ^
  symbol:   variable timeAvailable
  location: variable __stateAvailable of type Bid.State_Available
1 error
javac exited with value 1`