### PR TITLE
Add @ notation to constructors.

### DIFF
--- a/resources/case_studies/Insurance/Bank.obs
+++ b/resources/case_studies/Insurance/Bank.obs
@@ -7,7 +7,7 @@ main contract Bank {
     // the bank's private key for making tokens
     int key;
 
-    owned Bank() {
+    Bank() {
         // TODO: generate key
         key = 35;
     }

--- a/resources/case_studies/Insurance/Bid.obs
+++ b/resources/case_studies/Insurance/Bid.obs
@@ -12,7 +12,7 @@ main resource contract Bid {
     // client buys it
     state Sold {}
 
-    owned Bid(int c, int expirationDate) {
+    Bid@Available(int c, int expirationDate) {
         cost = c;
         // Available by default
         ->Available(timeAvailable = expirationDate);

--- a/resources/case_studies/Insurance/BidTokenPair.obs
+++ b/resources/case_studies/Insurance/BidTokenPair.obs
@@ -2,16 +2,16 @@ import "resources/case_studies/Insurance/Token.obs"
 import "resources/case_studies/Insurance/Bid.obs"
 
 main resource contract BidTokenPair {
-    Bid@Owned bid;
+    Bid@Available bid;
     // TODO: Token or Tokens?
     Token@Owned token;
 
-    owned BidTokenPair(Bid@Owned b, Token@Owned t) {
+    BidTokenPair@Owned(Bid@Available b, Token@Owned t) {
         bid = b;
         token = t;
     }
 
-    transaction getBid() returns Bid@Owned {
+    transaction getBid() returns Bid@Available {
         return bid;
     }
 

--- a/resources/case_studies/Insurance/InsuranceClient.obs
+++ b/resources/case_studies/Insurance/InsuranceClient.obs
@@ -12,13 +12,13 @@ main contract InsuranceClient {
 	     insService.connectBankAndInsurer(bank);
 
          Token@Owned token = bank.buyToken();
-	     Bid@Owned bid = insService.requestBids(3);
+	     Bid@Available bid = insService.requestBids(3);
 
          // test
          if (bid.getCost() == 7) {
              System.print("bid : 7 \n");
          }
-
+         // TODO: return Bid@Sold (issue 140)
          Bid@Owned soldBid = insService.buyBid(bid, token);
 
          // to pass typechecker

--- a/resources/case_studies/Insurance/InsuranceService.obs
+++ b/resources/case_studies/Insurance/InsuranceService.obs
@@ -6,7 +6,7 @@ main resource contract InsuranceService {
     Insurer ins;
     Token@Owned tokens;
 
-    owned InsuranceService() {}
+    InsuranceService@Owned() {}
 
 
     transaction addInsurer(Insurer insurer) {
@@ -21,18 +21,19 @@ main resource contract InsuranceService {
     }
 
     // TODO: information to calculate bids, Collection of Bid and Token
-    transaction requestBids(int x) returns Bid@Owned {
-        BidTokenPair bidAndTokens = ins.requestBids(x);
+    transaction requestBids(int i) returns Bid@Available {
+        BidTokenPair bidAndTokens = ins.requestBids(i);
 
         // TODO: add Tokens from bidAndTokens to Tokens
         // TODO: how to keep track of tokens for each client?
         tokens = bidAndTokens.getToken();
-        Bid@Owned bid = bidAndTokens.getBid();
+        Bid@Available bid = bidAndTokens.getBid();
 
         return bid;
     }
 
-    transaction buyBid(Bid@Owned bid, Token@Owned token) returns Bid@Owned {
+    // TODO: return Bid@Sold (issue 140)
+    transaction buyBid(Bid@Available bid, Token@Owned token) returns Bid@Available {
         // TODO: collect all tokens together (ones given by insurer and insuree) (for now just disown)
         disown token;
         // TODO: switch bid states with bid.buy();

--- a/resources/case_studies/Insurance/Insurer.obs
+++ b/resources/case_studies/Insurance/Insurer.obs
@@ -9,7 +9,7 @@ main contract Insurer {
     //TODO: owned Money mon;
     Bank bank;
 
-    owned Insurer() {}
+    Insurer() {}
 
     transaction addBank(Bank b) {
         bank = b;
@@ -22,7 +22,7 @@ main contract Insurer {
         int timeAvailable = 100;
         // TODO : give Money to Bank for Token
         Token@Owned t = bank.buyToken();
-        Bid@Owned b = new Bid(cost, timeAvailable);
+        Bid@Available b = new Bid(cost, timeAvailable);
 
         return new BidTokenPair(b, t);
     }

--- a/resources/case_studies/Insurance/Money.obs
+++ b/resources/case_studies/Insurance/Money.obs
@@ -2,11 +2,11 @@
 resource contract Money {
     int amount;
 
-    owned Money(int amt) {
+    Money@Owned(int amt) {
         amount = amt;
     }
 
-    transaction addMoney(owned Money m) {
+    transaction addMoney(Money@Owned m) {
          amount = amount + m.amount;
          disown m;
     }

--- a/resources/case_studies/Insurance/Token.obs
+++ b/resources/case_studies/Insurance/Token.obs
@@ -2,7 +2,7 @@ main resource contract Token {
     // bank's private key, only banks can make tokens
     int bankKey;
 
-    owned Token(int key) {
+    Token@Owned(int key) {
 
         //TODO: check that key is valid to make token
         if (true) {

--- a/resources/tests/parser_tests/InvokableSpec.obs
+++ b/resources/tests/parser_tests/InvokableSpec.obs
@@ -9,9 +9,10 @@ contract C {
 
     C() { return; }
 
-    C() ends in S1 { return; }
+    C@S1() { return; }
 
-    C() ends in S1, S2 { return; }
+    // don't support state unions yet
+    C@S1() { return; }
 
 
     transaction t() { return; }

--- a/resources/tests/parser_tests/StateInitialization.obs
+++ b/resources/tests/parser_tests/StateInitialization.obs
@@ -13,7 +13,7 @@ main contract Test {
 
     int shared available in S1, S2;
 
-    Test()  ends in S1 {   
+    Test@S1() {
     	S1::x1 = 42;
 	S1::shared = 44;
 

--- a/resources/tests/type_checker_tests/Assignment.obs
+++ b/resources/tests/type_checker_tests/Assignment.obs
@@ -7,7 +7,7 @@ resource contract C_Owned {
 main contract C_Shared {
     int f1;
 
-    C_Shared() ends in S {
+    C_Shared@S()  {
         ->S(f2 = f1);
     }
 

--- a/resources/tests/type_checker_tests/CheckFields.obs
+++ b/resources/tests/type_checker_tests/CheckFields.obs
@@ -8,7 +8,7 @@ contract C1 {
 }
 
 resource contract C2 {
-  owned C2(){
+  C2@S(){
     ->S;
   }
   state S {}

--- a/resources/tests/type_checker_tests/Dereference.obs
+++ b/resources/tests/type_checker_tests/Dereference.obs
@@ -4,8 +4,8 @@ contract Thing {
     int x;
     string y;
     bool z;
-
-    Thing(int x) {
+    // don't really support inferring types yet
+    Thing@Shared(int x) {
         this.x = x;
         this.y = "a";
         this.z = true;

--- a/resources/tests/type_checker_tests/EndsInState.obs
+++ b/resources/tests/type_checker_tests/EndsInState.obs
@@ -1,6 +1,6 @@
 main contract C {
     // error: constructor for 'C' ends in S1 instead of S2
-    C() ends in S2 {
+    C@S2() {
         ->S1;
     }
 

--- a/resources/tests/type_checker_tests/EndsInStateUnion.obs
+++ b/resources/tests/type_checker_tests/EndsInStateUnion.obs
@@ -1,6 +1,6 @@
 main contract C1 {
 
-    // error: constructor for 'C1' ends in S2, S3 instead of S1, S2
+    // error: constructor for 'C1' ends in S2, S3 instead of S1
     C1@S1(bool b){
         if(b) {
             ->S2;

--- a/resources/tests/type_checker_tests/EndsInStateUnion.obs
+++ b/resources/tests/type_checker_tests/EndsInStateUnion.obs
@@ -1,7 +1,7 @@
 main contract C1 {
 
     // error: constructor for 'C1' ends in S2, S3 instead of S1, S2
-    C1(bool b) ends in S1, S2 {
+    C1@S1(bool b){
         if(b) {
             ->S2;
         } else {
@@ -30,7 +30,7 @@ main contract C1 {
 contract C2 {
 
     // error: C2 ends in S1, S2 but must end in S1
-    C2(bool b) ends in S1 {
+    C2@S1(bool b) {
         if(b) {
             ->S1;
         } else {

--- a/resources/tests/type_checker_tests/MaybeDroppedResource.obs
+++ b/resources/tests/type_checker_tests/MaybeDroppedResource.obs
@@ -1,7 +1,7 @@
 resource contract Money {}
 
 main resource contract Wallet {
-	 owned Wallet() {
+	 Wallet@Owned() {
 	 	  ->Empty;
 	 }
 

--- a/resources/tests/type_checker_tests/Resources.obs
+++ b/resources/tests/type_checker_tests/Resources.obs
@@ -7,7 +7,7 @@ main resource contract BogusMoney {
 }
 
 resource contract Money {
-    owned Money() {
+    Money@Owned() {
 
     }
 }
@@ -15,7 +15,7 @@ resource contract Money {
 resource contract Wallet {
     Money@Owned money;
 
-    owned Wallet (Money@Owned m) {
+    Wallet@Owned(Money@Owned m) {
         money = m;
     }
 

--- a/resources/tests/type_checker_tests/Return.obs
+++ b/resources/tests/type_checker_tests/Return.obs
@@ -2,7 +2,7 @@
  * properties about statement sequences w.r.t. returns */
 
 resource contract C_Owned {
-  owned C_Owned() {
+  C_Owned@Owned() {
     ->S;
   }
   state S {}

--- a/resources/tests/type_checker_tests/StateInitialization.obs
+++ b/resources/tests/type_checker_tests/StateInitialization.obs
@@ -12,7 +12,7 @@ main contract Test {
 
     int shared available in S1, S2;
 
-    Test()  ends in S1 {   
+    Test@S1() {
     	S1::x1 = 42;
         S1::x2 = 43;
         S1::shared = 44;

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -3,7 +3,7 @@ package edu.cmu.cs.obsidian.parser
 import scala.util.parsing.input.{NoPosition, Position}
 import edu.cmu.cs.obsidian.lexer.Token
 import edu.cmu.cs.obsidian.parser.Parser.{EndsInState, Identifier}
-import edu.cmu.cs.obsidian.typecheck.{ContractReferenceType, ContractType, StateType, InterfaceContractType, NonPrimitiveType, ObsidianType, Permission}
+import edu.cmu.cs.obsidian.typecheck._
 
 trait HasLocation {
     var loc: Position = NoPosition
@@ -129,9 +129,7 @@ case class Transaction(name: String,
                        body: Seq[Statement],
                        isStatic: Boolean,
                        thisType: NonPrimitiveType,
-                       thisFinalType: NonPrimitiveType,
-                       thisPermission: Permission, // TODO: refactor this
-                       thisFinalPermission: Permission) extends InvokableDeclaration with IsAvailableInStates {
+                       thisFinalType: NonPrimitiveType) extends InvokableDeclaration with IsAvailableInStates {
     val tag: DeclarationTag = TransactionDeclTag
 
     // contract name is necessary since we don't have it at parse time

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -2,8 +2,8 @@ package edu.cmu.cs.obsidian.parser
 
 import scala.util.parsing.input.{NoPosition, Position}
 import edu.cmu.cs.obsidian.lexer.Token
-import edu.cmu.cs.obsidian.parser.Parser.Identifier
-import edu.cmu.cs.obsidian.typecheck.{ObsidianType, Permission}
+import edu.cmu.cs.obsidian.parser.Parser.{EndsInState, Identifier}
+import edu.cmu.cs.obsidian.typecheck.{ContractReferenceType, ContractType, StateType, InterfaceContractType, NonPrimitiveType, ObsidianType, Permission}
 
 trait HasLocation {
     var loc: Position = NoPosition
@@ -41,7 +41,6 @@ sealed abstract class InvokableDeclaration() extends Declaration {
     val args: Seq[VariableDecl]
     val retType: Option[ObsidianType]
     val body: Seq[Statement]
-    val endsInState: Option[Set[Identifier]]
 }
 
 /* Expressions */
@@ -108,9 +107,8 @@ case class Field(isConst: Boolean,
 }
 
 case class Constructor(name: String,
-                       isOwned: Boolean,
                        args: Seq[VariableDecl],
-                       endsInState: Option[Set[Identifier]],
+                       resultType: NonPrimitiveType,
                        body: Seq[Statement]) extends InvokableDeclaration {
     val retType: Option[ObsidianType] = None
     val tag: DeclarationTag = ConstructorDeclTag
@@ -121,7 +119,6 @@ case class Func(name: String,
                 availableIn: Option[Set[Identifier]],
                 body: Seq[Statement],
                 thisPermission: Permission) extends InvokableDeclaration with IsAvailableInStates {
-    val endsInState: Option[Set[Identifier]] = None
     val tag: DeclarationTag = FuncDeclTag
 }
 case class Transaction(name: String,
@@ -129,12 +126,26 @@ case class Transaction(name: String,
                        retType: Option[ObsidianType],
                        availableIn: Option[Set[Identifier]],
                        ensures: Seq[Ensures],
-                       endsInState: Option[Set[Identifier]],
                        body: Seq[Statement],
                        isStatic: Boolean,
+                       thisType: NonPrimitiveType,
+                       thisFinalType: NonPrimitiveType,
                        thisPermission: Permission, // TODO: refactor this
                        thisFinalPermission: Permission) extends InvokableDeclaration with IsAvailableInStates {
     val tag: DeclarationTag = TransactionDeclTag
+
+    // contract name is necessary since we don't have it at parse time
+    def thisType(contractName: String): NonPrimitiveType = typeWithContractName(thisType, contractName)
+
+    def thisFinalType(contractName: String): NonPrimitiveType = typeWithContractName(thisFinalType, contractName)
+
+    private def typeWithContractName(typ: NonPrimitiveType, contractName: String): NonPrimitiveType =
+        typ match {
+            case ContractReferenceType(ContractType(_), permission, isRemote) =>
+                ContractReferenceType(ContractType(contractName), permission, isRemote)
+            case StateType(_, stateNames, isRemote) => StateType(contractName, stateNames, isRemote)
+            case InterfaceContractType(_, simpleType) =>  InterfaceContractType(contractName, simpleType)
+        }
 }
 case class State(name: String, declarations: Seq[Declaration]) extends Declaration {
     val tag: DeclarationTag = StateDeclTag

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -89,23 +89,7 @@ object Parser extends Parsers {
              opt(RemoteT()) ~ parseId ~ opt(AtT() ~! parseId) ^^ {
                 case remote ~ id ~ permission => {
                     val isRemote = remote.isDefined
-                    val typ =
-                        permission match {
-                            case None => ContractReferenceType(ContractType(id._1), Inferred(), isRemote)
-                            case Some(_ ~ permissionIdent) =>
-                                if (permissionIdent._1 == "Shared") {
-                                    ContractReferenceType(ContractType(id._1), Shared(), isRemote)
-                                }
-                                else if (permissionIdent._1 == "Owned") {
-                                    ContractReferenceType(ContractType(id._1), Owned(), isRemote)
-                                }
-                                else if (permissionIdent._1 == "Unowned") {
-                                    ContractReferenceType(ContractType(id._1), Unowned(), isRemote)
-                                }
-                                else {
-                                    StateType(id._1, permissionIdent._1, isRemote)
-                                }
-                        }
+                    val typ = extractTypeFromPermission(permission, id, isRemote)
                     typ.setLoc(id)
                 }
             }
@@ -116,6 +100,25 @@ object Parser extends Parsers {
         val stringPrim = StringT() ^^ { t => StringType().setLoc(t) }
 
         parseNonPrimitive | intPrim | boolPrim | stringPrim
+    }
+
+    private def extractTypeFromPermission(permission: Option[~[Token, Identifier]], name: Identifier, isRemote: Boolean): NonPrimitiveType = {
+        permission match {
+            case None => ContractReferenceType(ContractType(name._1), Inferred(), isRemote)
+            case Some(_ ~ permissionIdent) =>
+                if (permissionIdent._1 == "Shared") {
+                    ContractReferenceType(ContractType(name._1), Shared(), isRemote)
+                }
+                else if (permissionIdent._1 == "Owned") {
+                    ContractReferenceType(ContractType(name._1), Owned(), isRemote)
+                }
+                else if (permissionIdent._1 == "Unowned") {
+                    ContractReferenceType(ContractType(name._1), Unowned(), isRemote)
+                }
+                else {
+                    StateType(name._1, permissionIdent._1, isRemote)
+                }
+        }
     }
 
     private def parseArgList: Parser[Seq[Expression]] = repsep(parseExpr, CommaT())
@@ -424,8 +427,20 @@ object Parser extends Parsers {
                     case MainT() => "main"
                     case id => id.asInstanceOf[Identifier]._1
                 }
+
+                // contract name is THIS as there is no way to access it at the moment
+                val thisType = transOptions.availableIn match {
+                    case None => ContractReferenceType(ContractType("THIS"), Shared(), false)
+                    case Some(s) => StateType("THIS", s.map(_._1), false)
+                }
+
+                val finalType = transOptions.endsInState match {
+                    case None => ContractReferenceType(ContractType("THIS"), Shared(), false)
+                    case Some(s) => StateType("THIS", s.map(_._1), false)
+                }
+
                 Transaction(nameString, args, transOptions.returnType, transOptions.availableIn,
-                    ensures, transOptions.endsInState, body, isStatic, Shared(), Shared()).setLoc(t)
+                    ensures, body, isStatic, thisType, finalType, Shared(), Shared()).setLoc(t)
         }
     }
     //keep returns first, take union of available ins and ends in
@@ -487,10 +502,11 @@ object Parser extends Parsers {
 
     // maybe we can check here that the constructor has the appropriate name?
     private def parseConstructor = {
-        opt(OwnedT()) ~ parseId ~ LParenT() ~! parseArgDefList ~! RParenT() ~! opt(parseEndsInState) ~!
-        LBraceT() ~! parseBody ~! RBraceT() ^^ {
-            case isOwned ~ name ~ _ ~ args ~ _ ~ ensuresState ~ _ ~ body ~ _ =>
-                Constructor(name._1, isOwned.isDefined, args, ensuresState, body).setLoc(name)
+        parseId ~ opt(AtT() ~! parseId) ~! LParenT() ~! parseArgDefList ~! RParenT() ~! LBraceT() ~! parseBody ~! RBraceT() ^^ {
+            case name ~ permission ~ _ ~ args ~ _ ~ _ ~ body ~ _ =>
+                val resultType = extractTypeFromPermission(permission, name, isRemote = false)
+
+                Constructor(name._1, args, resultType, body).setLoc(name)
         }
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -440,7 +440,7 @@ object Parser extends Parsers {
                 }
 
                 Transaction(nameString, args, transOptions.returnType, transOptions.availableIn,
-                    ensures, body, isStatic, thisType, finalType, Shared(), Shared()).setLoc(t)
+                    ensures, body, isStatic, thisType, finalType).setLoc(t)
         }
     }
     //keep returns first, take union of available ins and ends in

--- a/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
@@ -76,7 +76,7 @@ object ProtobufGen {
             case b@edu.cmu.cs.obsidian.typecheck.BoolType() => ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), f.name)
             case s@edu.cmu.cs.obsidian.typecheck.StringType() => ProtobufField(edu.cmu.cs.obsidian.protobuf.StringType(), f.name)
                 // TODO: get the right type for the state if this is type specifies typestate?
-            case np: NonPrimitiveType => ProtobufField(edu.cmu.cs.obsidian.protobuf.ObjectType(np.toString), f.name)
+            case np: NonPrimitiveType => ProtobufField(edu.cmu.cs.obsidian.protobuf.ObjectType(np.contractName), f.name)
             case BottomType() => assert(false, "Bottom type should not occur at codegen time"); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
             case u@UnresolvedNonprimitiveType(_, _) => assert(false, "Unresolved types should not occur at codegen time"); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
         }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
@@ -205,10 +205,10 @@ object AstTransformer {
             table: SymbolTable,
             lexicallyInsideOf: DeclarationTable,
             t: Transaction): (Transaction, Seq[ErrorRecord]) = {
-        val context = startContext(lexicallyInsideOf, t.args, t.thisPermission)
+        val context = startContext(lexicallyInsideOf, t.args, t.thisType.permission)
 
 
-        var (newArgs, argErrors) = transformArgs(table, lexicallyInsideOf, t.args, t.thisPermission)
+        var (newArgs, argErrors) = transformArgs(table, lexicallyInsideOf, t.args, t.thisType.permission)
 
         val newEnsures = t.ensures.map(en => en.copy(expr = transformExpression(en.expr)))
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -493,7 +493,6 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                  val result =
                      checkArgs(e, s"constructor of $name", context, constrSpecs, This(), argTypes)
 
-                 // TODO: https://github.com/mcoblenz/Obsidian/issues/63
                  val simpleType = result match {
                      // Even if the args didn't check, we can still output a type
                      case None => ContractReferenceType(ctTableOfConstructed.contractType, Owned(), false)
@@ -1519,7 +1518,6 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             case _ => ()
         }
 
-        // TODO: make this owned?
         val expectedThisType: NonPrimitiveType = constr.resultType
         checkIsSubtype(constr, outputContext("this"), expectedThisType)
 
@@ -1542,12 +1540,12 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             logError(contract, MultipleConstructorsError(contract.name))
         }
 
-        val constructorsByArgTypes = constructors.groupBy(c => c.args.map(_.typ))
+        val constructorsByArgTypes = constructors.groupBy(c => c.args.map(_.typ.topPermissionType))
         val matchingConstructors = constructorsByArgTypes.filter(_._2.size > 1)
 
         matchingConstructors.foreach(typeAndConstructors => {
-            val highestLine = typeAndConstructors._2.maxBy(_.loc.line)
-            logError(highestLine, RepeatConstructorsError(contract.name))
+            val greatestLine = typeAndConstructors._2.maxBy(_.loc.line)
+            logError(greatestLine, RepeatConstructorsError(contract.name))
         })
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -213,7 +213,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     //-------------------------------------------------------------------------
     /* Helper functions to easily make new types */
 
-    /* Determines what sort of simple type should be used, given a set a possible states */
+    /*/* Determines what sort of simple type should be used, given a set a possible states */
     // TODO: refactor this when we support specifying permissions on "this" for transactions
     private def simpleOfWithStateNames(cName: String, states: Option[Set[String]], permission: Permission): NonPrimitiveType = {
         states match {
@@ -230,7 +230,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             case Some(ss) => Some(ss.map(_._1))
         }
         simpleOfWithStateNames(cName, stateNames, permission)
-    }
+    }*/
 
 
     //-------------------------------------------------------------------------
@@ -247,7 +247,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             case (StateType(_, ss1, _), StateType(_, ss2, _)) =>
                 val c = t1.contractName
                 val unionStates = ss1.union(ss2)
-                Some(simpleOfWithStateNames(c, Some(unionStates), Owned()))
+                Some(StateType(c, unionStates, false))
             case _ => None
         }
     }
@@ -497,8 +497,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                  val simpleType = result match {
                      // Even if the args didn't check, we can still output a type
                      case None => ContractReferenceType(ctTableOfConstructed.contractType, Owned(), false)
-                     case Some((constr, _)) =>
-                         simpleOf(contextPrime.contractTable, name, constr.endsInState, Owned())
+                     case Some((constr, _)) => constr.resultType
                  }
 
                  (simpleType, contextPrime)
@@ -1291,20 +1290,22 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         val outputContext =
             checkStatementSequence(tx, initContext, tx.body)
 
+        val expectedType = tx.thisFinalType(lexicallyInsideOf.contract.name)
         // Check that all the states the transaction can end in are valid, named states
-        if (tx.endsInState.isDefined) {
-            for (state <- tx.endsInState.get) {
-                val stateTableOpt = lexicallyInsideOf.contractTable.state(state._1)
-                stateTableOpt match {
-                    case None => logError(tx, StateUndefinedError(lexicallyInsideOf.contract.name, state._1))
-                    case Some(_) => ()
+        expectedType match {
+            case StateType(_, states, _) => {
+                for (stateName <- states) {
+                    val stateTableOpt = lexicallyInsideOf.contractTable.state(stateName)
+                    stateTableOpt match {
+                        case None => logError(tx, StateUndefinedError(lexicallyInsideOf.contract.name, stateName))
+                        case Some(_) => ()
+                    }
                 }
             }
+            case _ => ()
         }
 
         // TODO: make the permission depend on the transaction's specification
-        val expectedType =
-            simpleOf(lexicallyInsideOf, lexicallyInsideOf.name, tx.endsInState, tx.thisFinalPermission)
         checkIsSubtype(tx, outputContext("this"), expectedType)
 
         checkForUnusedStateInitializers(outputContext)
@@ -1354,8 +1355,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         else {
             None
         }
-        val thisType = simpleOfWithStateNames(lexicallyInsideOf.contract.name, stateNames, tx.thisPermission)
 
+        val thisType = tx.thisType(lexicallyInsideOf.contract.name)
         // TODO: consider path case. Previously it was something like:
         // PathType("this"::"parent"::Nil, lexicallyInsideOf.simpleType)
         val table = thisType match {
@@ -1478,7 +1479,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             logError(constr, ConstructorNameError(table.name))
         }
 
-        if (table.contract.isResource && !constr.isOwned) {
+        if (table.contract.isResource && !constr.resultType.isOwned) {
             logError(constr, ResourceContractConstructorError(table.name))
         }
 
@@ -1505,18 +1506,21 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             checkStatementSequence(constr, initContext, constr.body)
 
         // Check that all the states the constructor can end in are valid, named states
-        if (constr.endsInState.isDefined) {
-            for (stateName <- constr.endsInState.get.map(_._1)) {
-                val stateTableOpt = table.contractTable.state(stateName)
-                stateTableOpt match {
-                    case None => logError(constr, StateUndefinedError(table.contract.name, stateName))
-                    case Some(_) => ()
+        constr.resultType match {
+            case StateType(_, states, _) => {
+                for (stateName <- states) {
+                    val stateTableOpt = table.contractTable.state(stateName)
+                    stateTableOpt match {
+                        case None => logError(constr, StateUndefinedError(table.contract.name, stateName))
+                        case Some(_) => ()
+                    }
                 }
             }
+            case _ => ()
         }
 
         // TODO: make this owned?
-        val expectedThisType = simpleOf(table, table.name, constr.endsInState, Owned())
+        val expectedThisType: NonPrimitiveType = constr.resultType
         checkIsSubtype(constr, outputContext("this"), expectedThisType)
 
         checkForUnusedOwnershipErrors(constr, outputContext, Set("this"))
@@ -1527,6 +1531,24 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             logError(constr, NoStartStateError(constr.name))
         }
 
+    }
+
+    private def checkConstructors(constructors: Seq[Constructor], contract: Contract, table: ContractTable): Unit = {
+        if (constructors.isEmpty && table.stateLookup.nonEmpty) {
+            logError(contract, NoConstructorError(contract.name))
+        }
+
+        if (constructors.length > 1 && contract.isMain) {
+            logError(contract, MultipleConstructorsError(contract.name))
+        }
+
+        val constructorsByArgTypes = constructors.groupBy(c => c.args.map(_.typ))
+        val matchingConstructors = constructorsByArgTypes.filter(_._2.size > 1)
+
+        matchingConstructors.foreach(typeAndConstructors => {
+            val highestLine = typeAndConstructors._2.maxBy(_.loc.line)
+            logError(highestLine, RepeatConstructorsError(contract.name))
+        })
     }
 
     private def checkForMainContract(ast: Program) = {
@@ -1550,14 +1572,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 case _ => () // TODO
             }
         }
+        checkConstructors(table.constructors, contract, table)
 
-        if (table.constructors.isEmpty && table.stateLookup.nonEmpty) {
-            logError(contract, NoConstructorError(contract.name))
-        }
-
-        if (table.constructors.length > 1 && contract.modifiers.contains(IsMain())) {
-            logError(contract, MultipleConstructorsError(contract.name))
-        }
     }
 
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -181,6 +181,10 @@ case class MultipleConstructorsError(contractName: String) extends Error {
     val msg: String = s"Main contract '$contractName' must only contain one constructor."
 }
 
+case class RepeatConstructorsError(contractName: String) extends Error {
+    val msg: String = s"Contract '$contractName' has multiple constructors that take the same arguments."
+}
+
 case class NoParentError(cName: String) extends Error {
     val msg: String = s"Contract $cName has no parent contract"
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -252,6 +252,11 @@ class TypeCheckerTests extends JUnitSuite {
         runTest("resources/tests/type_checker_tests/Construction.obs",
             (ConstructorNameError("Thing"), 27)
                 ::
+                (RepeatConstructorsError("Thing"), 27)
+                ::
+                (SubtypingError(ContractReferenceType(ContractType("Thing"), Owned(), false),
+                                ContractReferenceType(ContractType("OtherThing"), Inferred(), false)), 27)
+                ::
                 (WrongArityError(0, 1, "constructor of Thing"), 37)
                 ::
                 (SubtypingError(
@@ -410,7 +415,7 @@ class TypeCheckerTests extends JUnitSuite {
         runTest("resources/tests/type_checker_tests/EndsInStateUnion.obs",
             (SubtypingError(
                 StateType("C1", Set("S2", "S3"), false),
-                StateType("C1", Set("S1", "S2"), false)), 4
+                StateType("C1", Set("S1"), false)), 4
             )
                 ::
                 (StateUndefinedError("C1", "OtherState"), 13)


### PR DESCRIPTION
Add @ notation to constructors, i.e. `owned C() {...}` becomes `C@Owned() {...}` and `C() ends in S {...}` becomes `C@S() {...}`. Refactored some things in the checker as well - `InvokableDeclarations` no longer have an `endsInState` field; instead, the type is constructed while parsing.

This eliminates the need for `simpleOf` and `simpleOfWithStateNames` in the type checker, which were helpers to construct these types. These functions were basically copied to `parseTransDecl` to create fields `thisType` (which is the type the transaction is available in) and `thisFinalType` (which is the type the transaction ends in). 

There was already a mechanism to extract a type based on the permission within parsing, so I used that for extracting the type of the constructor.

Since the syntax changed, some of the tests had to change. Currently, we don't support state unions in the parser, so the `EndsInStateUnion.obs` test will have to change back once this is supported.