### PR TITLE
Improve handling of transaction invocations (#131)

### DIFF
--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ChaincodeBaseMock.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ChaincodeBaseMock.java
@@ -136,6 +136,11 @@ class ChaincodeBaseServer {
                 failureMessage = ": Reentrant call made";
             } catch (BadTransactionException e) {
                 System.out.println("Invalid state access");
+            } catch (NoSuchTransactionException e) {
+                /* This should never happen, because it won't compile if you
+                 * reference a nonexistent transaction. */
+                System.out.println("Invalid transaction call " + txName);
+                failureMessage = ": No such transaction: " + txName;
             }
         }
         else if (method.equals("query")) {
@@ -283,7 +288,8 @@ public abstract class ChaincodeBaseMock {
     public abstract byte[] init(ChaincodeStubMock stub, byte[][] args)
             throws InvalidProtocolBufferException;
     public abstract byte[] run(ChaincodeStubMock stub, String transactionName, byte[][] args)
-            throws InvalidProtocolBufferException, ReentrancyException, BadTransactionException;
+            throws InvalidProtocolBufferException, ReentrancyException,
+                   BadTransactionException, NoSuchTransactionException;
     public abstract ChaincodeBaseMock __initFromArchiveBytes(byte[] archiveBytes) throws InvalidProtocolBufferException;
     public abstract byte[] __archiveBytes();
 }

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/HyperledgerChaincodeBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/HyperledgerChaincodeBase.java
@@ -18,7 +18,7 @@ import java.util.Base64;
 import org.hyperledger.fabric.shim.ChaincodeBase;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-public abstract class ObsidianChaincodeBase extends ChaincodeBase {
+public abstract class HyperledgerChaincodeBase extends ChaincodeBase {
     @Override
     public Response init(ChaincodeStub stub) {
         final String function = stub.getFunction();
@@ -112,6 +112,6 @@ public abstract class ObsidianChaincodeBase extends ChaincodeBase {
     public abstract byte[] run(ChaincodeStub stub, String transactionName, byte[][] args)
             throws InvalidProtocolBufferException, ReentrancyException,
                    BadTransactionException, NoSuchTransactionException;
-    public abstract ObsidianChaincodeBase __initFromArchiveBytes(byte[] archiveBytes) throws InvalidProtocolBufferException;
+    public abstract HyperledgerChaincodeBase __initFromArchiveBytes(byte[] archiveBytes) throws InvalidProtocolBufferException;
     public abstract byte[] __archiveBytes();
 }

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/NoSuchTransactionException.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/NoSuchTransactionException.java
@@ -1,0 +1,7 @@
+package edu.cmu.cs.obsidian.chaincode;
+
+/**
+ * Created by Miles Baker on 7/3/18.
+ */
+public class NoSuchTransactionException extends Exception {
+}

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ObsidianChaincodeBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ObsidianChaincodeBase.java
@@ -51,6 +51,8 @@ public abstract class ObsidianChaincodeBase extends ChaincodeBase {
         try {
             byte result[] = run(stub, function, byte_args);
             return newSuccessResponse(result);
+        } catch (NoSuchTransactionException e) {
+            return newErrorResponse("No such transaction: " + function);
         } catch (Throwable e) {
             return newErrorResponse(e);
         }
@@ -105,7 +107,8 @@ public abstract class ObsidianChaincodeBase extends ChaincodeBase {
     public abstract byte[] init(ChaincodeStub stub, byte[][] args)
             throws InvalidProtocolBufferException;
     public abstract byte[] run(ChaincodeStub stub, String transactionName, byte[][] args)
-            throws InvalidProtocolBufferException, ReentrancyException, BadTransactionException;
+            throws InvalidProtocolBufferException, ReentrancyException,
+                   BadTransactionException, NoSuchTransactionException;
     public abstract ObsidianChaincodeBase __initFromArchiveBytes(byte[] archiveBytes) throws InvalidProtocolBufferException;
     public abstract byte[] __archiveBytes();
 }

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ObsidianChaincodeBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/ObsidianChaincodeBase.java
@@ -52,6 +52,9 @@ public abstract class ObsidianChaincodeBase extends ChaincodeBase {
             byte result[] = run(stub, function, byte_args);
             return newSuccessResponse(result);
         } catch (NoSuchTransactionException e) {
+            /* This will be returned when calling an invalid transaction
+             * from the command line -- referencing an invalid transaction
+             * in the client will give a compile-time error. */
             return newErrorResponse("No such transaction: " + function);
         } catch (Throwable e) {
             return newErrorResponse(e);

--- a/buildscript/build.gradle
+++ b/buildscript/build.gradle
@@ -19,7 +19,7 @@ repositories {
 sourceSets {
     main {
         java {
-            srcDirs = ["../$codeDirectory", '../Obsidian Runtime/src/Runtime']
+            srcDirs = ["$codeDirectory", '../Obsidian Runtime/src/Runtime']
         }
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -228,7 +228,7 @@ object Main {
                 val path = Paths.get(p)
                 /* create the dir if it doesn't exist */
                 Files.createDirectories(path)
-                path
+                path.toAbsolutePath
             case None => Files.createTempDirectory("obsidian").toAbsolutePath
         }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -937,7 +937,12 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
 
         noSuchTransactionBody._throw(JExpr._new(model.ref("edu.cmu.cs.obsidian.chaincode.NoSuchTransactionException")))
 
-        runMeth.body()._return(returnBytes)
+        /* Don't return anything if we put the 'throw' directly in the method body, since
+         * it will make the java compiler complain about 'unreachable code.' */
+        lastTransactionElse match {
+            case None =>
+            case Some(_) => runMeth.body()._return(returnBytes)
+        }
     }
 
     private def generateServerMainMethod(newClass: JDefinedClass) = {

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -707,7 +707,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         if (mockChaincode) {
             newClass._extends(model.directClass("edu.cmu.cs.obsidian.chaincode.ChaincodeBaseMock"))
         } else {
-            newClass._extends(model.directClass("edu.cmu.cs.obsidian.chaincode.ObsidianChaincodeBase"))
+            newClass._extends(model.directClass("edu.cmu.cs.obsidian.chaincode.HyperledgerChaincodeBase"))
         }
 
         val stubType = if (mockChaincode) {


### PR DESCRIPTION
So it turned out we basically already supported invoking transactions from the command line, but there was still some cleanup-type stuff to do:

Also, I added code to make it reject when the provided transaction name doesn't match any transaction. This is prevented by the compiler when you compile the client, but there was no runtime check, which meant that you wouldn't get an error when running a nonexistent transaction from the command line. This will also presumably come in handy if people want to only write their chaincode in Obsidian, and interface with it some other way.

(I also had to add handling for this to the mock-chaincode mode, but that will probably never actually be an issue.)