### PR TITLE
Give a better error message when trying to assign a field in class body

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -366,9 +366,11 @@ object Parser extends Parsers {
         simpleExpr ~ parseDots ^^ { case e ~ applyDots => applyDots(e) }
     }
 
-    private def parseFieldDecl = {
-        opt(ConstT()) ~ parseType ~ parseId ~! opt(parseAvailableIn) ~! SemicolonT() ^^ {
-            case isConst ~ typ ~ name ~ availableIn ~ _ =>
+    private def parseFieldDecl: Parser[Declaration] = {
+        opt(ConstT()) ~ parseType ~ parseId ~! opt(parseAvailableIn) ~!
+                opt(EqT() ~! parseExpr ~! failure("fields may only be assigned inside of transactions")) ~!
+                SemicolonT() ^^ {
+            case isConst ~ typ ~ name ~ availableIn ~ None ~ _ =>
                 isConst match {
                     case Some(constToken) =>
                         Field(isConst = true, typ, name._1, availableIn).setLoc(constToken)


### PR DESCRIPTION
I'm not 100% sure that this is the best way to accomplish this, but it wouldn't let me put the `failure` inside the `^^ { }` function, and this way does seem to work. Do let me know if there's a more idiomatic-Scala-parser-library way to do it, though.