### PR TITLE
Issue 78

### DIFF
--- a/resources/tests/IntContainerClient.obs
+++ b/resources/tests/IntContainerClient.obs
@@ -2,7 +2,7 @@ import "resources/tests/IntContainer.obs"
 import "Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/java-utilities/System.obs"
 
 main contract IntContainerClient {
-    transaction main(remote IntContainer container) {
+    transaction main(remote IntContainer@Shared container) {
         int oldX = container.setX(3);
         System.println(oldX);
         oldX = container.setX(4);

--- a/resources/tests/compilerTests/IntContainerClient.obs
+++ b/resources/tests/compilerTests/IntContainerClient.obs
@@ -2,7 +2,7 @@ import "Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/java-utilities/System.o
 import "resources/tests/IntContainer.obs"
 
 main contract IntContainerClient {
-    transaction main(remote IntContainer container) {
+    transaction main(remote IntContainer@Shared container) {
         int oldX = container.setX(3);
         container.setX(4);
         System.print("setX : 4");

--- a/resources/tests/compilerTests/StateTransactions.obs
+++ b/resources/tests/compilerTests/StateTransactions.obs
@@ -12,11 +12,11 @@ main contract A {
    }
 
 
-   transaction t() available in S1, S2 {
+   transaction t(A@(S1|S2) this) {
        int x = 3;
    }
 
-   transaction inState3() available in S3 {
+   transaction inState3(A@S3 this) {
        y = 4;
    }
 

--- a/resources/tests/parser_tests/AvailableInRepeats.obs
+++ b/resources/tests/parser_tests/AvailableInRepeats.obs
@@ -5,6 +5,6 @@ main contract C {
         function f() returns int available in S1 { return x; }
         function f(T x) { return x; }
     }
-    transaction t() available in S1 available in S2 { return x; }
-    transaction t(T x) available in S1 { return x; }
+    transaction t(C@(S1|S2) this) { return x; }
+    transaction t(C@S1 this, T x) { return x; }
 }

--- a/resources/tests/parser_tests/BadTransactionOrdering.obs
+++ b/resources/tests/parser_tests/BadTransactionOrdering.obs
@@ -3,6 +3,6 @@ main contract C {
         function f() { return x; }
         function f(T x) { return x; }
     }
-    transaction t() available in S1 returns int { return x; }
-    transaction t(T x) returns int available in S1 { return x; }
+    transaction t(C@S1 this) returns int { return x; }
+    transaction t(C@S1 this. T x) returns int { return x; }
 }

--- a/resources/tests/parser_tests/InvokableSpec.obs
+++ b/resources/tests/parser_tests/InvokableSpec.obs
@@ -1,4 +1,3 @@
-/* for now, the ordering is 'requires -> returns -> ensures' */
 
 // NOTE: this file should parse, but not type-check
 

--- a/resources/tests/parser_tests/InvokableSpec.obs
+++ b/resources/tests/parser_tests/InvokableSpec.obs
@@ -11,8 +11,7 @@ contract C {
 
     C@S1() { return; }
 
-    // don't support state unions yet
-    C@S1() { return; }
+    C@(S1|S2)() { return; }
 
 
     transaction t() { return; }
@@ -25,9 +24,7 @@ contract C {
 
     transaction t() returns C_Owned { return; }
 
-    transaction t() returns C_Owned
-                    ends in S1 { return; }
+    transaction t(C@S1 this) returns C_Owned { return; }
 
-    transaction t() returns C_Owned
-                    ends in S1, S2 { return; }
+    transaction t(C@(S1|S2) this) returns C_Owned { return; }
 }

--- a/resources/tests/parser_tests/ValidTransactions.obs
+++ b/resources/tests/parser_tests/ValidTransactions.obs
@@ -3,6 +3,6 @@ main contract C {
         function f() returns int available in S1 { return x; }
         function f(T x) { return x; }
     }
-    transaction t() returns int available in S1 { return x; }
-    transaction t(T x) available in S1 { return x; }
+    transaction t(C@S1 this) returns int { return x; }
+    transaction t(C@S1 this, T x) { return x; }
 }

--- a/resources/tests/type_checker_tests/ArgumentShadowing.obs
+++ b/resources/tests/type_checker_tests/ArgumentShadowing.obs
@@ -5,7 +5,7 @@ state S {
     int y;
  }
 
- transaction t(C x) available in S
+ transaction t(C@S this, C@Unowned x)
  { ->S(x = y, y = x); }
 
 }

--- a/resources/tests/type_checker_tests/ArgumentShadowing.obs
+++ b/resources/tests/type_checker_tests/ArgumentShadowing.obs
@@ -1,11 +1,14 @@
-main contract C { C() {->S(x=0, y=0); }
+main contract C {
 
-state S {
-    int x;
-    int y;
- }
+    C@S() { ->S(x=0, y=0); }
 
- transaction t(C@S this, C@Unowned x)
- { ->S(x = y, y = x); }
+    state S {
+        int x;
+        int y;
+    }
+
+    transaction t(C@Unowned >> S this, C@Unowned x) {
+        ->S(x = y, y = x);
+    }
 
 }

--- a/resources/tests/type_checker_tests/EndsInState.obs
+++ b/resources/tests/type_checker_tests/EndsInState.obs
@@ -5,8 +5,7 @@ main contract C {
     }
 
     // error: t ends in S2 instead of S1
-    transaction t() available in S2
-                    ends in S1 {
+    transaction t(C@S2 >> S1 this) {
         int x = 1;
     }
 

--- a/resources/tests/type_checker_tests/EndsInStateUnion.obs
+++ b/resources/tests/type_checker_tests/EndsInStateUnion.obs
@@ -9,14 +9,12 @@ main contract C1 {
     }
 
     // error: 'OtherState' is not a valid state
-    transaction t1() available in S2
-                    ends in S2, OtherState {
+    transaction t1(C1@S2 >> (S2|OtherState) this) {
         int x = 1;
     }
 
     // error: if we access t2 from S2, it will not end in S1, S3
-    transaction t2() available in S1, S2
-                     ends in S1, S3 {
+    transaction t2(C1@(S1|S2) >> (S1|S3) this) {
         int x = 1;
     }
 
@@ -52,7 +50,7 @@ contract C3 {
     ->S1;
   }
 
-  transaction toUnknownState(int x) available in S1 ends in S1, S2 {
+  transaction toUnknownState(C3@S1 >> (S1|S2) this, int x) {
     if (x > 3) {
       ->S2(f2 = 0);
     }

--- a/resources/tests/type_checker_tests/MaybeDroppedResource.obs
+++ b/resources/tests/type_checker_tests/MaybeDroppedResource.obs
@@ -12,12 +12,12 @@ main resource contract Wallet {
 	 state Empty {
 	 }
 
-	 transaction loseMoney() available in Full, Empty {
+	 transaction loseMoney(Wallet@(Full|Empty) this) {
 	       // Error -- maybe losing Money!
 	       ->Empty;
 	 }
 
-	 transaction loseMoney(Money@Owned n) {
+	 transaction loseMoney(Money@Owned >> Unowned n) {
 	       disown n;
 	 }
 }

--- a/resources/tests/type_checker_tests/MaybeDroppedResource.obs
+++ b/resources/tests/type_checker_tests/MaybeDroppedResource.obs
@@ -12,7 +12,7 @@ main resource contract Wallet {
 	 state Empty {
 	 }
 
-	 transaction loseMoney(Wallet@(Full|Empty) this) {
+	 transaction loseMoney(Wallet@Full >> Empty this) {
 	       // Error -- maybe losing Money!
 	       ->Empty;
 	 }

--- a/resources/tests/type_checker_tests/MultistateFields.obs
+++ b/resources/tests/type_checker_tests/MultistateFields.obs
@@ -9,17 +9,17 @@ main contract MultistateFields {
 
   int foo available in S1, S2;
 
-  transaction setFoo(int f) available in S1, S2 {
+  transaction setFoo(C@(S1|S2) this, int f) {
     foo = f;
     int x = foo;
   }
 
-  transaction invalidSetFoo1(int f) available in S3 {
+  transaction invalidSetFoo1(C@S3 this, int f) {
     // Error: foo not available in S3
     foo = f;
   }
 
-  transaction invalidSetFoo2(int f) available in S2, S3 {
+  transaction invalidSetFoo2(C@(S2|S3) this, int f) {
     // Error: foo not available in S3
     foo = f;
 

--- a/resources/tests/type_checker_tests/Ownership.obs
+++ b/resources/tests/type_checker_tests/Ownership.obs
@@ -8,7 +8,7 @@ contract Prescription {
 main contract Pharmacy {
     Prescription@Owned prescription;
 
-    transaction depositPrescription(Prescription@Owned p) {
+    transaction depositPrescription(Prescription@Owned >> Unowned p) {
         prescription = p;
     }
 

--- a/resources/tests/type_checker_tests/Resources.obs
+++ b/resources/tests/type_checker_tests/Resources.obs
@@ -28,7 +28,7 @@ resource contract Wallet {
         money = m;
     }
 
-    transaction returnMoney (Money@Owned m) returns Money@Owned {
+    transaction returnMoney (Money@Owned >> Unowned m) returns Money@Owned {
     	return m;
     }
 
@@ -49,7 +49,7 @@ contract Disowning {
 	 	     disown m;
 	 }
 
-	 transaction discardMoney (Money@Owned m) {
+	 transaction discardMoney (Money@Owned >> Unowned m) {
      	 	 disown m;
 
      	 	 // Error: m is unowned

--- a/resources/tests/type_checker_tests/StartState.obs
+++ b/resources/tests/type_checker_tests/StartState.obs
@@ -21,7 +21,7 @@ contract HasStates {
 
     }
 
-    transaction a(HasStates@Start this) {
+    transaction a(HasStates@Start >> S1 this) {
          ->S1;
     }
 }
@@ -34,7 +34,7 @@ main contract StatesNoConstr {
 
     }
 
-    transaction a(StatesNoConstr@Start this) {
+    transaction a(StatesNoConstr@Start >> S1 this) {
         ->S1;
     }
     state S1 {

--- a/resources/tests/type_checker_tests/StartState.obs
+++ b/resources/tests/type_checker_tests/StartState.obs
@@ -21,7 +21,7 @@ contract HasStates {
 
     }
 
-    transaction a() available in Start{
+    transaction a(HasStates@Start this) {
          ->S1;
     }
 }
@@ -34,7 +34,7 @@ main contract StatesNoConstr {
 
     }
 
-    transaction a() available in Start {
+    transaction a(StatesNoConstr@Start this) {
         ->S1;
     }
     state S1 {

--- a/resources/tests/type_checker_tests/States.obs
+++ b/resources/tests/type_checker_tests/States.obs
@@ -7,7 +7,7 @@ main contract C {
     state Start {
     }
 
-    transaction a(C@Start this) {
+    transaction a(C@Start >> S1 this) {
         ->S1;
         // should fail: need to assign x
         ->S2;

--- a/resources/tests/type_checker_tests/States.obs
+++ b/resources/tests/type_checker_tests/States.obs
@@ -7,7 +7,7 @@ main contract C {
     state Start {
     }
 
-    transaction a() available in Start {
+    transaction a(C@Start this) {
         ->S1;
         // should fail: need to assign x
         ->S2;

--- a/resources/tests/type_checker_tests/States.obs
+++ b/resources/tests/type_checker_tests/States.obs
@@ -18,7 +18,7 @@ main contract C {
         ->S1(x = 1);
     }
 
-    transaction b() {
+    transaction b(C@Start >> S1 this) {
         ->S1;
     }
 

--- a/resources/tests/type_checker_tests/Transitions.obs
+++ b/resources/tests/type_checker_tests/Transitions.obs
@@ -9,12 +9,12 @@ main contract Test {
 
     state S2;
 
-    transaction foo() {
+    transaction foo(Test@S2 >> S1 this) {
         S1::x1 = 42;
     	->S1;
     }
 
-    transaction bar() {
+    transaction bar(Test@S1 >> S2 this) {
         ->S2;
     }
 

--- a/resources/tests/type_checker_tests/TypeSpecification.obs
+++ b/resources/tests/type_checker_tests/TypeSpecification.obs
@@ -1,0 +1,77 @@
+main contract C {
+
+    state S1;
+    state S2;
+    state S3;
+
+    C@S1() {
+        ->S1;
+    }
+
+    // this should be fine, since we transition back to S1
+    transaction transitionsBack(C@S1 this) {
+
+        if (true) {
+            ->S2;
+        } else {
+            ->S3;
+        }
+
+        ->S1;
+    }
+
+    // this fails. since we don't transition back to S1
+    transaction badTransition(C@S1 this) {
+
+        if (true) {
+            ->S2;
+        } else {
+            ->S3;
+        }
+
+    }
+
+    transaction toS2(C@(S2|S3) this) {
+        ->S2;
+    }
+
+    transaction toS3(C@(S2|S3) this) {
+        ->S3;
+    }
+
+    transaction changeA(A@Available >> Unavailable a) {
+        a.makeUnavailable();
+    }
+
+    transaction changeA2(A@Unavailable >> Available a) {
+        a.makeAvailable();
+    }
+
+    // this errors since a switched states
+    transaction badChangeA(A@Unavailable a) {
+        a.makeAvailable();
+    }
+
+    // this errors since a switched states
+    transaction badChangeA2(A@Available a) {
+        a.makeUnavailable();
+    }
+
+}
+
+contract A {
+    state Available;
+    state Unavailable;
+
+    A() {
+        ->Available;
+    }
+
+    transaction makeUnavailable(A@Available >> Unavailable this) {
+        ->Unavailable;
+    }
+
+    transaction makeAvailable(A@Unavailable >> Available this) {
+        ->Available;
+    }
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -237,7 +237,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         var argExpressions: List[IJExpression] = Nil
         /* add args */
         for (arg <- transaction.args) {
-            argExpressions = argExpressions :+ meth.param(resolveType(arg.typ), arg.varName)
+            argExpressions = argExpressions :+ meth.param(resolveType(arg.typIn), arg.varName)
         }
 
         /* add body */
@@ -254,7 +254,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         for (i <- 0 until argExpressions.length) {
             val unmarshalledArg = argExpressions(i)
 
-            val marshalledArg = marshallExpr(unmarshalledArg, transaction.args(i).typ)
+            val marshalledArg = marshallExpr(unmarshalledArg, transaction.args(i).typIn)
             val setInvocation = body.invoke(argArray, "add")
             setInvocation.arg(marshalledArg)
         }
@@ -355,7 +355,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
 
 
       /* add the appropriate args to the method and collect them in a list */
-        val jArgs = txExample.args.map( (arg: VariableDecl) => meth.param(resolveType(arg.typ), arg.varName) )
+        val jArgs = txExample.args.map( (arg: VariableDeclWithSpec) => meth.param(resolveType(arg.typIn), arg.varName) )
 
         val body = meth.body()
 
@@ -393,7 +393,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         val meth = newClass.method(JMod.PUBLIC, retType, funExample.name)
 
         /* add the appropriate args to the method and collect them in a list */
-        val jArgs = funExample.args.map( (arg: VariableDecl) => meth.param(resolveType(arg.typ), arg.varName) )
+        val jArgs = funExample.args.map( (arg: VariableDeclWithSpec) => meth.param(resolveType(arg.typIn), arg.varName) )
 
         val body = meth.body()
 
@@ -725,7 +725,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         // gather the types of its arguments
         val constructorTypes: Seq[ObsidianType] =
             constructor match {
-                case Some(constr: Constructor) => constr.args.map(_.typ)
+                case Some(constr: Constructor) => constr.args.map(_.typIn)
                 case _ => List.empty
             }
 
@@ -850,9 +850,9 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
                 var runArgNumber = 0
                 for (txArg <- tx.args) {
                     val runArg = runArgs.component(JExpr.lit(runArgNumber))
-                    val javaArgType = resolveType(txArg.typ)
+                    val javaArgType = resolveType(txArg.typIn)
 
-                    val transactionArgExpr: IJExpression = txArg.typ match {
+                    val transactionArgExpr: IJExpression = txArg.typIn match {
                         case IntType() =>
                             JExpr._new(javaArgType).arg(runArg)
                         case BoolType() =>
@@ -966,7 +966,7 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
             val mainTransaction: Transaction = mainTransactionOption.get
 
             // The main transaction expects to be passed a stub of a particular type. Construct it.
-            val stubType: ObsidianType = mainTransaction.args(0).typ
+            val stubType: ObsidianType = mainTransaction.args(0).typIn
             val stubJavaType = resolveType(stubType)
             val newStubExpr = JExpr._new(stubJavaType)
             newStubExpr.arg(JExpr.ref("connectionManager"))
@@ -1638,8 +1638,8 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         }
 
         /* add args to method and collect them in a list */
-        val argList: Seq[(String, JVar)] = c.args.map((arg: VariableDecl) =>
-            (arg.varName, meth.param(resolveType(arg.typ), arg.varName))
+        val argList: Seq[(String, JVar)] = c.args.map((arg: VariableDeclWithSpec) =>
+            (arg.varName, meth.param(resolveType(arg.typIn), arg.varName))
         )
 
         /* construct the local context from this list */
@@ -1730,8 +1730,8 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         }
 
         /* add args to method and collect them in a list */
-        val argList: Seq[(String, JVar)] = tx.args.map((arg: VariableDecl) =>
-            (arg.varName, meth.param(resolveType(arg.typ), arg.varName))
+        val argList: Seq[(String, JVar)] = tx.args.map((arg: VariableDeclWithSpec) =>
+            (arg.varName, meth.param(resolveType(arg.typIn), arg.varName))
         )
 
         /* construct the local context from this list */
@@ -1945,8 +1945,8 @@ class CodeGen (val target: Target, val mockChaincode: Boolean) {
         val meth: JMethod = newClass.method(JMod.PRIVATE, javaRetType, decl.name)
 
         /* add args to method and collect them in a list */
-        val argList: Seq[(String, JVar)] = decl.args.map((arg: VariableDecl) =>
-            (arg.varName, meth.param(resolveType(arg.typ), arg.varName))
+        val argList: Seq[(String, JVar)] = decl.args.map((arg: VariableDeclWithSpec) =>
+            (arg.varName, meth.param(resolveType(arg.typIn), arg.varName))
         )
 
         /* construct the local context from this list */

--- a/src/main/scala/edu/cmu/cs/obsidian/lexer/Lexer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/lexer/Lexer.scala
@@ -103,6 +103,8 @@ object Lexer extends RegexParsers {
     private def lBracketP = """\[""".r ^^ (_ => LBracketT())
     private def rBracketP = """\]""".r ^^ (_ => RBracketT())
     private def pipeP = """\|""".r ^^ (_ => PipeT())
+    private def chevP = """>>""".r ^^ (_ => ChevT())
+
 
     private def oneToken: Parser[Token] =
 
@@ -112,7 +114,7 @@ object Lexer extends RegexParsers {
         lBraceP | rBraceP | lParenP | rParenP | commaP | dotP | semicolonP |
 
         /* order is important here because some tokens contain the others */
-        gtEqP | ltEqP | eqEqP | notEqP | rightArrowP | bigRightArrowP | ltP | gtP | eqP |
+        chevP | gtEqP | ltEqP | eqEqP | notEqP | rightArrowP | bigRightArrowP | ltP | gtP | eqP |
 
         plusP | starP | forwardSlashP | minusP | coloncolonP | atP | lBracketP | rBracketP | pipeP
     )

--- a/src/main/scala/edu/cmu/cs/obsidian/lexer/Token.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/lexer/Token.scala
@@ -78,6 +78,7 @@ case class AtT() extends Token { override def toString: String = "@" }
 case class LBracketT() extends Token { override def toString: String ="[" }
 case class RBracketT() extends Token { override def toString: String ="]" }
 case class PipeT() extends Token { override def toString: String ="|" }
+case class ChevT() extends Token { override def toString: String =">>" }
 
 
     /* comment token: the parser never sees this; comments should be pruned in the lexer */

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -38,7 +38,7 @@ sealed abstract class Declaration() extends AST {
 }
 
 sealed abstract class InvokableDeclaration() extends Declaration {
-    val args: Seq[VariableDecl]
+    val args: Seq[VariableDeclWithSpec]
     val retType: Option[ObsidianType]
     val body: Seq[Statement]
 }
@@ -79,6 +79,7 @@ case class StateInitializer(stateName: Identifier, fieldName: Identifier) extend
 /* statements and control flow constructs */
 case class VariableDecl(typ: ObsidianType, varName: String) extends Statement
 case class VariableDeclWithInit(typ: ObsidianType, varName: String, e: Expression) extends Statement
+case class VariableDeclWithSpec(typIn: ObsidianType, typOut: ObsidianType, varName: String) extends Statement
 case class Return() extends Statement
 case class ReturnExpr(e: Expression) extends Statement
 
@@ -110,14 +111,14 @@ case class Field(isConst: Boolean,
 }
 
 case class Constructor(name: String,
-                       args: Seq[VariableDecl],
+                       args: Seq[VariableDeclWithSpec],
                        resultType: NonPrimitiveType,
                        body: Seq[Statement]) extends InvokableDeclaration {
     val retType: Option[ObsidianType] = None
     val tag: DeclarationTag = ConstructorDeclTag
 }
 case class Func(name: String,
-                args: Seq[VariableDecl],
+                args: Seq[VariableDeclWithSpec],
                 retType: Option[ObsidianType],
                 availableIn: Option[Set[Identifier]],
                 body: Seq[Statement],
@@ -125,7 +126,7 @@ case class Func(name: String,
     val tag: DeclarationTag = FuncDeclTag
 }
 case class Transaction(name: String,
-                       args: Seq[VariableDecl],
+                       args: Seq[VariableDeclWithSpec],
                        retType: Option[ObsidianType],
                        availableIn: Option[Set[Identifier]],
                        ensures: Seq[Ensures],

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
@@ -289,7 +289,9 @@ object AstTransformer {
             case oldDecl@VariableDeclWithSpec(typIn, typOut, varName) =>
                 val (newTypIn, errorsIn) = transformType(table, lexicallyInsideOf, context, typIn, s.loc)
                 val (newTypOut, errorsOut) = transformType(table, lexicallyInsideOf, context, typOut, s.loc)
-                (oldDecl.copy(typIn = newTypIn, typOut = newTypOut).setLoc(oldDecl), context.updated(varName, newTypIn), errorsIn ++ errorsOut)
+                val newDecl = oldDecl.copy(typIn = newTypIn, typOut = newTypOut)
+                val totalErrors = errorsIn ++ errorsOut
+                (newDecl, context.updated(varName, newTypIn), totalErrors)
             case oldDecl@VariableDeclWithInit(typ, varName, e) =>
                 val (newTyp, errors) = transformType(table, lexicallyInsideOf, context, typ, s.loc)
                 val newDecl = oldDecl.copy(typ = newTyp, e = transformExpression(e)).setLoc(oldDecl)

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
@@ -170,7 +170,7 @@ object AstTransformer {
         }
     }
 
-    def startContext(lexicallyInsideOf: DeclarationTable, args: Seq[VariableDecl], thisPermission: Permission): Context = {
+    def startContext(lexicallyInsideOf: DeclarationTable, args: Seq[VariableDeclWithSpec], thisPermission: Permission): Context = {
         var startContext = emptyContext
 
         val simpleType =  ContractReferenceType(lexicallyInsideOf.contractType, thisPermission, false)
@@ -178,7 +178,7 @@ object AstTransformer {
         startContext = startContext.updated("this", contractType)
 
         for (a <- args) {
-            startContext = startContext.updated(a.varName, a.typ)
+            startContext = startContext.updated(a.varName, a.typIn)
         }
         startContext
     }
@@ -186,16 +186,16 @@ object AstTransformer {
     def transformArgs(
             table: SymbolTable,
             lexicallyInsideOf: DeclarationTable,
-            args: Seq[VariableDecl],
-            thisPermission: Permission): (Seq[VariableDecl], Seq[ErrorRecord]) = {
+            args: Seq[VariableDeclWithSpec],
+            thisPermission: Permission): (Seq[VariableDeclWithSpec], Seq[ErrorRecord]) = {
         var errors = List.empty[ErrorRecord]
-        var newArgs: Seq[VariableDecl] = Nil
+        var newArgs: Seq[VariableDeclWithSpec] = Nil
         val context = startContext(lexicallyInsideOf, args, thisPermission)
         for (a <- args) {
-            val (transformedType, newErrors) = transformType(table, lexicallyInsideOf, context - a.varName, a.typ, a.loc)
+            val (transformedType, newErrors) = transformType(table, lexicallyInsideOf, context - a.varName, a.typIn, a.loc)
             errors = errors ++ newErrors
 
-            val aNew = a.copy(typ = transformedType)
+            val aNew = a.copy(typIn = transformedType)
             newArgs = aNew +: newArgs
         }
         (newArgs.reverse, errors)
@@ -286,6 +286,10 @@ object AstTransformer {
                 val newTypChoice = transformType(table, lexicallyInsideOf, context, typ, s.loc)
                 val (newTyp, errors) = transformType(table, lexicallyInsideOf, context, typ, s.loc)
                 (oldDecl.copy(typ = newTyp).setLoc(oldDecl), context.updated(varName, newTyp), errors)
+            case oldDecl@VariableDeclWithSpec(typIn, typOut, varName) =>
+                val (newTypIn, errorsIn) = transformType(table, lexicallyInsideOf, context, typIn, s.loc)
+                val (newTypOut, errorsOut) = transformType(table, lexicallyInsideOf, context, typOut, s.loc)
+                (oldDecl.copy(typIn = newTypIn, typOut = newTypOut).setLoc(oldDecl), context.updated(varName, newTypIn), errorsIn ++ errorsOut)
             case oldDecl@VariableDeclWithInit(typ, varName, e) =>
                 val (newTyp, errors) = transformType(table, lexicallyInsideOf, context, typ, s.loc)
                 val newDecl = oldDecl.copy(typ = newTyp, e = transformExpression(e)).setLoc(oldDecl)

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1395,6 +1395,16 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         // TODO: make the permission depend on the transaction's specification
         checkIsSubtype(tx, outputContext("this"), expectedType)
 
+        // check that the arguments meet the correct specification afterwards
+        tx.args.foreach(arg => {
+            val actualTypOut = outputContext(arg.varName)
+
+            val errorOpt = isSubtype(actualTypOut, arg.typOut)
+            if (errorOpt.isDefined) {
+                logError(tx, ArgumentSpecificationError(arg.varName, tx.name, arg.typOut, actualTypOut))
+            }
+        })
+
         checkForUnusedStateInitializers(outputContext)
 
         if (tx.retType.isDefined & !hasReturnStatement(tx, tx.body)) {

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -733,7 +733,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             ast: AST,
             methName: String,
             context: Context,
-            spec: Seq[VariableDecl],
+            spec: Seq[VariableDeclWithSpec],
             receiver: Expression,
             args: Seq[(ObsidianType, Expression)]): Either[Seq[(AST, Error)], Map[String, Expression]] = {
 
@@ -751,7 +751,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             calleeToCaller = calleeToCaller.updated("this", receiver)
 
             val specCallerPoV: Seq[ObsidianType] = spec.map(arg => {
-                arg.typ match {
+                arg.typIn match {
                     case prim: PrimitiveType => prim
                     case np: NonPrimitiveType =>
                         toCallerPoV(calleeToCaller, np) match {
@@ -788,7 +788,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             ast: AST,
             methName: String,
             context: Context,
-            specs: Seq[(Seq[VariableDecl], U)],
+            specs: Seq[(Seq[VariableDeclWithSpec], U)],
             receiver: Expression,
             args: Seq[(ObsidianType, Expression)]): Option[(U, Map[String, Expression])] = {
 
@@ -1334,7 +1334,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         var context = initContext
 
         for (arg <- tx.args) {
-            context = initContext.updated(arg.varName, arg.typ)
+            context = initContext.updated(arg.varName, arg.typIn)
         }
 
         // Check the body; ensure [this] is well-typed after, and check for leaked ownership
@@ -1431,7 +1431,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
         // Add all the args first (in an unsafe way) before checking anything
         for (arg <- tx.args) {
-            initContext = initContext.updated(arg.varName, arg.typ)
+            initContext = initContext.updated(arg.varName, arg.typIn)
         }
 
         checkTransactionArgShadowing(startStates, tx)
@@ -1539,7 +1539,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
         // Add all the args first (in an unsafe way) before checking anything
         for (arg <- constr.args) {
-            context = context.updated(arg.varName, arg.typ)
+            context = context.updated(arg.varName, arg.typIn)
         }
 
         val stateSet: Set[(String, StateTable)] = table.stateLookup.toSet
@@ -1592,7 +1592,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             logError(contract, MultipleConstructorsError(contract.name))
         }
 
-        val constructorsByArgTypes = constructors.groupBy(c => c.args.map(_.typ.topPermissionType))
+        val constructorsByArgTypes = constructors.groupBy(c => c.args.map(_.typIn.topPermissionType))
         val matchingConstructors = constructorsByArgTypes.filter(_._2.size > 1)
 
         matchingConstructors.foreach(typeAndConstructors => {

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -229,5 +229,5 @@ case class StaticAssertInvalidState(contractName: String, stateOrPermission: Str
 
 case class ArgumentSpecificationError(arg: String, transactionName: String, t1: ObsidianType, t2: ObsidianType) extends Error {
     val msg: String = s"The argument '$arg' in transaction '$transactionName' was specified to end as type '$t1', " +
-        s"but actuals ends as type '$t2'."
+        s"but actually ends as type '$t2'."
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -231,3 +231,8 @@ case class ArgumentSpecificationError(arg: String, transactionName: String, t1: 
     val msg: String = s"The argument '$arg' in transaction '$transactionName' was specified to end as type '$t1', " +
         s"but actually ends as type '$t2'."
 }
+
+case class ThisSpecificationError(transactionName: String, contractName: String, stateName: String) extends Error {
+    val msg: String = s"Transaction '$transactionName' specified that it does not change the state of '$contractName', " +
+        s"but it does. Consider specifying 'this' to change to '$stateName'."
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -231,8 +231,3 @@ case class ArgumentSpecificationError(arg: String, transactionName: String, t1: 
     val msg: String = s"The argument '$arg' in transaction '$transactionName' was specified to end as type '$t1', " +
         s"but actually ends as type '$t2'."
 }
-
-case class ThisSpecificationError(transactionName: String, contractName: String, stateName: String) extends Error {
-    val msg: String = s"Transaction '$transactionName' specified that it does not change the state of '$contractName', " +
-        s"but it does. Consider specifying 'this' to change to '$stateName'."
-}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -226,3 +226,8 @@ case class StaticAssertFailed(e: Expression, statesOrPermissions: Seq[String], a
 case class StaticAssertInvalidState(contractName: String, stateOrPermission: String) extends Error {
     val msg: String = s"Cannot assert for invalid state '$stateOrPermission' in contract $contractName"
 }
+
+case class ArgumentSpecificationError(arg: String, transactionName: String, t1: ObsidianType, t2: ObsidianType) extends Error {
+    val msg: String = s"The argument '$arg' in transaction '$transactionName' was specified to end as type '$t1', " +
+        s"but actuals ends as type '$t2'."
+}

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
@@ -91,7 +91,7 @@ class ParserTests extends JUnitSuite {
               |     state S1 {
               |     }
               |
-              |     transaction t1 () available in S1 {
+              |     transaction t1 (C@S1 this) {
               |       x = (x.f.y.z((((5)))));
               |       (x).f = (new A()).f;
               |     }
@@ -108,7 +108,7 @@ class ParserTests extends JUnitSuite {
               |     state S1 {
               |
               |     }
-              |     transaction t1() available in S1 {
+              |     transaction t1(C@S1 this) {
               |             x.x = x.f1.f2.f3();
               |             x = x();
               |             x();
@@ -149,9 +149,9 @@ class ParserTests extends JUnitSuite {
               |         function f(T1 x, T2 y, T3 z) { return x; }
               |
               |     }
-              |     transaction t() available in S1 { return x; }
-              |         transaction t(T x) available in S1 { return x; }
-              |         transaction t(T1 x, T2 y, T3 z) available in S1 {
+              |     transaction t(C@S1 this) { return x; }
+              |         transaction t(C@S1 this, T x) { return x; }
+              |         transaction t(C@S1 this, T1 x, T2 y, T3 z) {
               |             f(x, y, z);
               |             f();
               |             x.f(x, y, z);
@@ -184,25 +184,25 @@ class ParserTests extends JUnitSuite {
         shouldSucceed(
             """ main contract C { state S {
               | }
-              | transaction t(T x) available in S { ->S(x = y, y = x); }
+              | transaction t(C@S this, T x) { ->S(x = y, y = x); }
               | }
             """.stripMargin)
         shouldSucceed(
             """ main contract C { state S {
               | }
-              | transaction t(T x) available in S { ->S(); }
+              | transaction t(C@S this, T x) { ->S(); }
               | }
             """.stripMargin)
         shouldSucceed(
             """ main contract C { state S {
               | }
-              |  transaction t(T x) available in S { ->S; }
+              |  transaction t(C@S this, T x) { ->S; }
               | }
             """.stripMargin)
         shouldSucceed(
             """ main contract C { state S {
               | }
-              |  transaction t(T x) available in S { ->S(x = y); }
+              |  transaction t(C@S this, T x) { ->S(x = y); }
               | }
             """.stripMargin)
     }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -331,10 +331,7 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def stateTest(): Unit = {
         runTest("resources/tests/type_checker_tests/States.obs",
-            (SubtypingError(StateType("C", "S1", false),
-                            StateType("C", "Start", false)), 10)
-                ::
-                (TransitionUpdateError(Set("x")), 13)
+            (TransitionUpdateError(Set("x")), 13)
                 ::
                 (StateUndefinedError("C", "S3"), 15)
                 ::
@@ -379,13 +376,7 @@ class TypeCheckerTests extends JUnitSuite {
         runTest("resources/tests/type_checker_tests/StartState.obs",
             (NoStartStateError("HasStates"), 12)
                 ::
-                (SubtypingError(StateType("HasStates", "S1", false),
-                                StateType("HasStates", "Start", false)), 24)
-                ::
                 (NoConstructorError("StatesNoConstr"), 31)
-                ::
-                (SubtypingError(StateType("StatesNoConstr", "S1", false),
-                                StateType("StatesNoConstr", "Start", false)), 37)
                 ::
                 Nil
         )

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -574,16 +574,33 @@ class TypeCheckerTests extends JUnitSuite {
         )
     }
 
-  @Test def staticAssertsTest(): Unit = {
-    runTest("resources/tests/type_checker_tests/StaticAsserts.obs",
-      (StaticAssertInvalidState("C", "S3"), 6)
-        ::
-        (StaticAssertFailed(This(), Seq("S2"), StateType("C", Set("S1", "S2"), false)), 17)
-        ::
-        (StaticAssertFailed(ReferenceIdentifier("ow"), Seq("Unowned"), ContractReferenceType(ContractType("C"), Owned(), false)), 24)
-        ::
-        Nil
-    )
+    @Test def staticAssertsTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/StaticAsserts.obs",
+            (StaticAssertInvalidState("C", "S3"), 6)
+              ::
+              (StaticAssertFailed(This(), Seq("S2"), StateType("C", Set("S1", "S2"), false)), 17)
+              ::
+              (StaticAssertFailed(ReferenceIdentifier("ow"), Seq("Unowned"), ContractReferenceType(ContractType("C"), Owned(), false)), 24)
+              ::
+              Nil
+        )
+    }
+
+    @Test def typeSpecificationTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/TypeSpecification.obs",
+            (SubtypingError (StateType("C", Set("S3", "S2"), false),
+                             StateType("C", "S1", false)), 24)
+              ::
+              (ArgumentSpecificationError("a", "badChangeA",
+                  StateType("A", "Unavailable", false),
+                  StateType("A", "Available", false)), 51)
+              ::
+              (ArgumentSpecificationError("a", "badChangeA2",
+                  StateType("A", "Available", false),
+                  StateType("A", "Unavailable", false)), 56)
+              ::
+              Nil
+        )
   }
 
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -560,7 +560,7 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def argShadowingTest(): Unit = {
         runTest("resources/tests/type_checker_tests/ArgumentShadowing.obs",
-            (ArgShadowingError("x", "t", 4), 8)
+            (ArgShadowingError("x", "t", 6), 10)
               ::
               Nil
         )

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -331,7 +331,10 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def stateTest(): Unit = {
         runTest("resources/tests/type_checker_tests/States.obs",
-            (TransitionUpdateError(Set("x")), 13)
+            (SubtypingError(StateType("C", "S1", false),
+                            StateType("C", "Start", false)), 10)
+                ::
+                (TransitionUpdateError(Set("x")), 13)
                 ::
                 (StateUndefinedError("C", "S3"), 15)
                 ::
@@ -376,7 +379,13 @@ class TypeCheckerTests extends JUnitSuite {
         runTest("resources/tests/type_checker_tests/StartState.obs",
             (NoStartStateError("HasStates"), 12)
                 ::
+                (SubtypingError(StateType("HasStates", "S1", false),
+                                StateType("HasStates", "Start", false)), 24)
+                ::
                 (NoConstructorError("StatesNoConstr"), 31)
+                ::
+                (SubtypingError(StateType("StatesNoConstr", "S1", false),
+                                StateType("StatesNoConstr", "Start", false)), 37)
                 ::
                 Nil
         )
@@ -415,16 +424,16 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (SubtypingError(
                     StateType("C1", Set("S1", "S2"), false),
-                    StateType("C1", Set("S1", "S3"), false)), 18
+                    StateType("C1", Set("S1", "S3"), false)), 17
                 )
                 ::
                 (SubtypingError(
                     StateType("C2", Set("S1", "S2"), false),
-                    StateType("C2", "S1", false)), 32
+                    StateType("C2", "S1", false)), 30
                 )
                 ::
                 (
-                    VariableUndefinedError("f2", null), 64
+                    VariableUndefinedError("f2", null), 62
                 )
                 ::
                 Nil


### PR DESCRIPTION
To support typestate specification to arguments, I added a new `VariableDeclWithSpec` ast to have the type coming in and type going out of a arguments to a transaction. There is an optional argument "this" that can be the first argument to a transaction to replace `available in` and `ends in`.