### PR TITLE
Don't generate -a file.

### DIFF
--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/HyperledgerChaincodeBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/HyperledgerChaincodeBase.java
@@ -102,9 +102,8 @@ public abstract class HyperledgerChaincodeBase extends ChaincodeBase {
              * by Hyperledger. Because arguments are an array, we have to copy
              * all the remaining arguments into a new array. */
             String[] less_args = new String[args.length - 1];
-            for (int i = 0; i < args.length - 1; i++) {
-                less_args[i] = args[i+1];
-            }
+            System.arraycopy(args, 1, less_args, 0, args.length-1);
+
             start(less_args);
         }
         catch (Exception e) {

--- a/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/HyperledgerChaincodeBase.java
+++ b/Obsidian Runtime/src/Runtime/edu/cmu/cs/obsidian/chaincode/HyperledgerChaincodeBase.java
@@ -98,7 +98,14 @@ public abstract class HyperledgerChaincodeBase extends ChaincodeBase {
 
         /* spin up server */
         try {
-            start(args);
+            /* Don't pass the first argument (archive path) to be processed
+             * by Hyperledger. Because arguments are an array, we have to copy
+             * all the remaining arguments into a new array. */
+            String[] less_args = new String[args.length - 1];
+            for (int i = 0; i < args.length - 1; i++) {
+                less_args[i] = args[i+1];
+            }
+            start(less_args);
         }
         catch (Exception e) {
             System.out.println("Error: Exception raised when running server: " + e);

--- a/buildscript/startfabric.sh
+++ b/buildscript/startfabric.sh
@@ -102,7 +102,7 @@ sleep $BETWEEN_PAUSE
 
 echo $CNORM'======= RUN CHAINCODE ======='
 sleep $ENTER_PAUSE
-java -jar $CCPATH -a $ip:7052 -i $CCNAME:$CCVERSION 2>&1 | sed "s/^/$CCODE[chaincode] /" &
+java -jar $CCPATH chaincode_archive -a $ip:7052 -i $CCNAME:$CCVERSION 2>&1 | sed "s/^/$CCODE[chaincode] /" &
 sleep 5
 echo $CNORM'===== CHAINCODE RUNNING ====='
 

--- a/buildscript/startfabric.sh
+++ b/buildscript/startfabric.sh
@@ -37,7 +37,8 @@ CCVERSION=0
 INIT_PARAMS=$2
 
 if [ "$2" == "clean" ]; then
-    rm ch1.block
+    rm -f ch1.block
+    rm -f chaincode_archive
     rm -rf /var/hyperledger/production
     mkdir /var/hyperledger/production
     INIT_PARAMS=$3


### PR DESCRIPTION
Apparently I forgot to make a pull request for this.

`-a` is now called `chaincode_archive`, which is clearer. But we'll probably remove this eventually as well once we actually get some sort of serialization to the blockchain.

Fixes #150 .