### PR TITLE
Issue 157: ReadOnlyState support

### DIFF
--- a/resources/tests/parser_tests/AvailableInRepeats.obs
+++ b/resources/tests/parser_tests/AvailableInRepeats.obs
@@ -2,8 +2,9 @@ main contract C {
     state S1 {
     }
     state S2 {
-        function f() returns int available in S1 { return x; }
-        function f(T x) { return x; }
+        // Disabled fuctions pending #159.
+        //function f() returns int available in S1 { return x; }
+        //function f(T x) { return x; }
     }
     transaction t(C@(S1|S2) this) { return x; }
     transaction t(C@S1 this, T x) { return x; }

--- a/resources/tests/parser_tests/ValidTransactions.obs
+++ b/resources/tests/parser_tests/ValidTransactions.obs
@@ -1,7 +1,8 @@
 main contract C {
     state S1 {
-        function f() returns int available in S1 { return x; }
-        function f(T x) { return x; }
+        // Disabled fuctions pending #159.
+        // function f() returns int available in S1 { return x; }
+        // function f(T x) { return x; }
     }
     transaction t(C@S1 this) returns int { return x; }
     transaction t(C@S1 this, T x) { return x; }

--- a/resources/tests/type_checker_tests/MultistateFields.obs
+++ b/resources/tests/type_checker_tests/MultistateFields.obs
@@ -9,17 +9,17 @@ main contract MultistateFields {
 
   int foo available in S1, S2;
 
-  transaction setFoo(C@(S1|S2) this, int f) {
+  transaction setFoo(MultistateFields@(S1|S2) this, int f) {
     foo = f;
     int x = foo;
   }
 
-  transaction invalidSetFoo1(C@S3 this, int f) {
+  transaction invalidSetFoo1(MultistateFields@S3 this, int f) {
     // Error: foo not available in S3
     foo = f;
   }
 
-  transaction invalidSetFoo2(C@(S2|S3) this, int f) {
+  transaction invalidSetFoo2(MultistateFields@(S2|S3) this, int f) {
     // Error: foo not available in S3
     foo = f;
 

--- a/resources/tests/type_checker_tests/ReadOnlyState.obs
+++ b/resources/tests/type_checker_tests/ReadOnlyState.obs
@@ -34,7 +34,7 @@ contract D {
     C@S1 s1C;
 
     transaction t1(C c) {
-        // Error: cannot change state of c
+        // Error: cannot change state of c.
         c.changeStateShared();
 
         // Error: cannot invoke.

--- a/resources/tests/type_checker_tests/ReadOnlyState.obs
+++ b/resources/tests/type_checker_tests/ReadOnlyState.obs
@@ -11,6 +11,7 @@ main contract C {
         ->S2;
     }
 
+    // OK because by default, 'this' is Shared.
     transaction changeStateShared() {
         ->S2;
     }
@@ -45,8 +46,9 @@ contract D {
     }
 
     transaction t2() {
-        s1C.invalidChangeState();
-        // s1C is now still in state S1
+        s1C.invalidChangeState(); // OK
+
+        // OK: s1C is now still in state S1
         s1C.changeStateStateSpecified();
     }
 }

--- a/resources/tests/type_checker_tests/ReadOnlyState.obs
+++ b/resources/tests/type_checker_tests/ReadOnlyState.obs
@@ -6,12 +6,47 @@ main contract C {
         ->S1;
     }
 
-    transaction t1(C this) {
+    transaction invalidChangeState(C this) {
         // error: can't change state of 'this'.
         ->S2;
     }
 
+    transaction changeStateShared() {
+        ->S2;
+    }
+
+    transaction changeStateOwned(C@Owned this) {
+        ->S2;
+    }
+
+    transaction changeStateStateSpecified(C@S1 >> S2 this) {
+        ->S2;
+    }
+
     // Error: int is the wrong type
-    transaction t2(int this) {
+    // transaction t2(int this) {
+    // }
+}
+
+contract D {
+    C@Shared sharedC;
+    C@Owned ownedC;
+    C@S1 s1C;
+
+    transaction t1(C c) {
+        // Error: cannot change state of c
+        c.changeStateShared();
+
+        // Error: cannot invoke.
+        c.changeStateOwned();
+
+        // Error: cannot invoke.
+        c.changeStateStateSpecified();
+    }
+
+    transaction t2() {
+        s1C.invalidStateChange();
+        // s1C is now still in state S1
+        s1c.changeStateStateSpecified();
     }
 }

--- a/resources/tests/type_checker_tests/ReadOnlyState.obs
+++ b/resources/tests/type_checker_tests/ReadOnlyState.obs
@@ -1,0 +1,17 @@
+main contract C {
+    state S1;
+    state S2;
+
+    C@S1() {
+        ->S1;
+    }
+
+    transaction t1(C this) {
+        // error: can't change state of 'this'.
+        ->S2;
+    }
+
+    // Error: int is the wrong type
+    transaction t2(int this) {
+    }
+}

--- a/resources/tests/type_checker_tests/ReadOnlyState.obs
+++ b/resources/tests/type_checker_tests/ReadOnlyState.obs
@@ -45,8 +45,8 @@ contract D {
     }
 
     transaction t2() {
-        s1C.invalidStateChange();
+        s1C.invalidChangeState();
         // s1C is now still in state S1
-        s1c.changeStateStateSpecified();
+        s1C.changeStateStateSpecified();
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -141,23 +141,11 @@ case class Transaction(name: String,
                        thisFinalType: NonPrimitiveType) extends InvokableDeclaration with IsAvailableInStates {
     val tag: DeclarationTag = TransactionDeclTag
 
-    // contract name is necessary since we don't have it at parse time
-    def thisType(contractName: String): NonPrimitiveType = typeWithContractName(thisType, contractName)
-
-    def thisFinalType(contractName: String): NonPrimitiveType = typeWithContractName(thisFinalType, contractName)
-
     def availableIn: Option[Set[String]] = thisType match {
         case StateType(_, stateNames, _) => Some(stateNames)
         case _ => None
     }
 
-    private def typeWithContractName(typ: NonPrimitiveType, contractName: String): NonPrimitiveType =
-        typ match {
-            case ContractReferenceType(ContractType(_), permission, isRemote) =>
-                ContractReferenceType(ContractType(contractName), permission, isRemote)
-            case StateType(_, stateNames, isRemote) => StateType(contractName, stateNames, isRemote)
-            case InterfaceContractType(_, simpleType) =>  InterfaceContractType(contractName, simpleType)
-        }
 }
 case class State(name: String, declarations: Seq[Declaration]) extends Declaration {
     val tag: DeclarationTag = StateDeclTag

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -41,6 +41,7 @@ sealed abstract class InvokableDeclaration() extends Declaration {
     val args: Seq[VariableDeclWithSpec]
     val retType: Option[ObsidianType]
     val body: Seq[Statement]
+    val thisType: ObsidianType
 }
 
 /* Expressions */
@@ -116,6 +117,7 @@ case class Constructor(name: String,
                        body: Seq[Statement]) extends InvokableDeclaration {
     val retType: Option[ObsidianType] = None
     val tag: DeclarationTag = ConstructorDeclTag
+    val thisType: ObsidianType = resultType
 }
 case class Func(name: String,
                 args: Seq[VariableDeclWithSpec],
@@ -124,6 +126,7 @@ case class Func(name: String,
                 body: Seq[Statement],
                 thisPermission: Permission) extends InvokableDeclaration with IsAvailableInStates {
     val tag: DeclarationTag = FuncDeclTag
+    val thisType: ObsidianType = BottomType() // TODO: merge Func into Transaction. This is bogus for now.
 }
 case class Transaction(name: String,
                        args: Seq[VariableDeclWithSpec],

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -42,6 +42,7 @@ sealed abstract class InvokableDeclaration() extends Declaration {
     val retType: Option[ObsidianType]
     val body: Seq[Statement]
     val thisType: ObsidianType
+    val isStatic: Boolean
 }
 
 /* Expressions */
@@ -118,6 +119,7 @@ case class Constructor(name: String,
     val retType: Option[ObsidianType] = None
     val tag: DeclarationTag = ConstructorDeclTag
     val thisType: ObsidianType = resultType
+    val isStatic: Boolean = false
 }
 case class Func(name: String,
                 args: Seq[VariableDeclWithSpec],
@@ -127,6 +129,7 @@ case class Func(name: String,
                 thisPermission: Permission) extends InvokableDeclaration with IsAvailableInStates {
     val tag: DeclarationTag = FuncDeclTag
     val thisType: ObsidianType = BottomType() // TODO: merge Func into Transaction (#159). This is bogus for now.
+    val isStatic: Boolean = false;
 }
 case class Transaction(name: String,
                        args: Seq[VariableDeclWithSpec],

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -392,11 +392,15 @@ object Parser extends Parsers {
                 opt(EqT() ~! parseExpr ~! failure("fields may only be assigned inside of transactions")) ~!
                 SemicolonT() ^^ {
             case isConst ~ typ ~ name ~ availableIn ~ None ~ _ =>
+                val availableInSet = availableIn match {
+                    case Some(idents) => Some(idents.map(_._1))
+                    case None => None
+                }
                 isConst match {
                     case Some(constToken) =>
-                        Field(isConst = true, typ, name._1, availableIn).setLoc(constToken)
+                        Field(isConst = true, typ, name._1, availableInSet).setLoc(constToken)
                     case None =>
-                        Field(isConst = false, typ, name._1, availableIn).setLoc(typ)
+                        Field(isConst = false, typ, name._1, availableInSet).setLoc(typ)
             }
         }
     }
@@ -420,6 +424,7 @@ object Parser extends Parsers {
             case _ ~ s => EndsInState(s)
         }
 
+/*
     private def parseFuncDecl = {
         FunctionT() ~! parseId ~! LParenT() ~! parseArgDefList ~! RParenT() ~!
             parseFuncOptions ~! LBraceT() ~! parseBody ~! RBraceT() ^^ {
@@ -427,6 +432,7 @@ object Parser extends Parsers {
                 Func(name._1, args, funcOptions.returnType, funcOptions.availableIn, body, Unowned()).setLoc(f)
         }
     }
+    */
 
     private def parseEnsures = {
         EnsuresT() ~! parseExpr ~! SemicolonT() ^^ {
@@ -506,7 +512,7 @@ object Parser extends Parsers {
 
                 }
 
-                Transaction(nameString, filteredArgs, returns, availableIn,
+                Transaction(nameString, filteredArgs, returns,
                     ensures, body, isStatic, thisType, finalType.asInstanceOf[NonPrimitiveType]).setLoc(t)
         }
     }
@@ -552,7 +558,7 @@ object Parser extends Parsers {
     }
 
     private def parseDeclInState: Parser[Declaration] = {
-        parseFieldDecl | parseFuncDecl |
+        parseFieldDecl | // parseFuncDecl |
         parseStateDecl | parseConstructor | parseContractDecl | failure("declaration expected")
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/StateFieldTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/StateFieldTransformer.scala
@@ -31,7 +31,7 @@ object StateFieldTransformer {
             state.declarations.foldLeft(Seq.empty[Field])((fieldsSoFar: Seq[Field], d: Declaration) =>
                 if (d.isInstanceOf[Field]) {
                     val f = d.asInstanceOf[Field]
-                    val newField = f.copy(availableIn = Some(Set((state.name, state.loc))))
+                    val newField = f.copy(availableIn = Some(Set(state.name)))
                     newField.setLoc(f)
                     newField +: fieldsSoFar
                 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/SymbolTable.scala
@@ -68,7 +68,7 @@ class StateTable(
                 if (found.isDefined) {
                     val availableIn = found.get.availableIn
                     if (availableIn.isDefined) {
-                        val availableInCurrentState = availableIn.get.exists(p => p._1 == name)
+                        val availableInCurrentState = availableIn.get.exists(p => p == name)
                         if (availableInCurrentState) found else None
                     }
                     else found // The field is available in all states.

--- a/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/protobuf/ProtobufGen.scala
@@ -79,6 +79,7 @@ object ProtobufGen {
             case np: NonPrimitiveType => ProtobufField(edu.cmu.cs.obsidian.protobuf.ObjectType(np.contractName), f.name)
             case BottomType() => assert(false, "Bottom type should not occur at codegen time"); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
             case u@UnresolvedNonprimitiveType(_, _) => assert(false, "Unresolved types should not occur at codegen time"); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
+            case UnitType() => assert(false, "Fields should not be of unit type."); ProtobufField(edu.cmu.cs.obsidian.protobuf.BoolType(), "bogus")
         }
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/AstTransformer.scala
@@ -391,6 +391,7 @@ object AstTransformer {
                         }
                     case None => (BottomType(), List(ErrorRecord(ContractUndefinedError(np.contractName), pos)))
                 }
+            case UnitType() => (t, List.empty)
         }
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -949,6 +949,10 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
                 val oldType = context.thisType
 
+                if (oldType.permission == ReadOnlyState()) {
+                    logError(s, TransitionNotAllowedError())
+                }
+
                 // First we focus on the fields declared in states individually.
                 // oldFields is the set of fields declared in the old state, which are definitely going away.
                 // maybeOldFields is the set of fields from the old state that MAY be going away — 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -347,7 +347,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 case (Some(t), _) => t
             }
 
-            if (isSubtype(receiverType, invokable.thisType).isDefined) {
+            if (!invokable.isStatic && isSubtype(receiverType, invokable.thisType).isDefined) {
                 logError(e, ReceiverTypeIncompatibleError(name, receiverType, invokable.thisType))
             }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -863,7 +863,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             case ReferenceIdentifier(x) => {
                 receiverType match {
                     case typ: NonPrimitiveType => {
-                        val newType = invokable.thisFinalType(typ.contractName)
+                        val newType = invokable.thisFinalType
                         if (newType.permission == ReadOnlyState()) {
                             // The transaction promised not to change the state of the receiver.
                             context
@@ -1351,7 +1351,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         val outputContext =
             checkStatementSequence(tx, initContext, tx.body)
 
-        val expectedType = tx.thisFinalType(lexicallyInsideOf.contract.name)
+        val expectedType = tx.thisFinalType
         // Check that all the states the transaction can end in are valid, named states
         expectedType match {
             case StateType(_, states, _) => {
@@ -1423,7 +1423,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     stateSet.map(s => s._2)
             }
 
-        val thisType = tx.thisType(lexicallyInsideOf.contract.name)
+        val thisType = tx.thisType
         // TODO: consider path case. Previously it was something like:
         // PathType("this"::"parent"::Nil, lexicallyInsideOf.simpleType)
         val table = thisType match {

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -240,3 +240,8 @@ case class InvalidInconsistentFieldType(fieldName: String, actualType: ObsidianT
     val msg: String = s"At the ends of transactions, all fields must reference objects consistent with their declared types. " +
         s" Field '$fieldName' is of type $actualType but was declared as $expectedType."
 }
+
+case class TransitionNotAllowedError() extends Error {
+    val msg: String = "Cannot change state because 'this' was specified to not allow state changes."
+}
+

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -245,3 +245,6 @@ case class TransitionNotAllowedError() extends Error {
     val msg: String = "Cannot change state because 'this' was specified to not allow state changes."
 }
 
+case class ReceiverTypeIncompatibleError(transactionName: String, actualType: ObsidianType, expectedType: ObsidianType) extends Error {
+    val msg: String = s"Cannot invoke $transactionName on a receiver of type $actualType; a receiver of type $expectedType is required."
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
@@ -16,8 +16,12 @@ case class Unowned() extends Permission {
 
 case class Inferred() extends Permission {
     override def toString: String = "Inferred"
+} // For local variables
+
+case class ReadOnlyState() extends Permission {
+    override def toString: String = "ReadOnlyState"
 }
-// For local variables
+
 
 // Type of references to contracts.
 case class ContractReferenceType(contractType: ContractType, permission: Permission, override val isRemote: Boolean) extends NonPrimitiveType {

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
@@ -144,9 +144,10 @@ class ParserTests extends JUnitSuite {
             """
               | main contract C {
               |     state S1 {
-              |         function f() { return x; }
-              |         function f(T x) { return x; }
-              |         function f(T1 x, T2 y, T3 z) { return x; }
+//                        Disabled fuctions pending #159.
+//              |         function f() { return x; }
+//              |         function f(T x) { return x; }
+//              |         function f(T1 x, T2 y, T3 z) { return x; }
               |
               |     }
               |     transaction t(C@S1 this) { return x; }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -129,7 +129,7 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def fieldsTest(): Unit = {
         runTest("resources/tests/type_checker_tests/CheckFields.obs",
-                Nil
+            Nil
         )
     }
 
@@ -257,7 +257,7 @@ class TypeCheckerTests extends JUnitSuite {
                 (RepeatConstructorsError("Thing"), 27)
                 ::
                 (SubtypingError(ContractReferenceType(ContractType("Thing"), Owned(), false),
-                                ContractReferenceType(ContractType("OtherThing"), Inferred(), false)), 27)
+                    ContractReferenceType(ContractType("OtherThing"), Inferred(), false)), 27)
                 ::
                 (WrongArityError(0, 1, "constructor of Thing"), 37)
                 ::
@@ -295,21 +295,21 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def branchingTest(): Unit = {
         runTest("resources/tests/type_checker_tests/Branching.obs",
-                        (MergeIncompatibleError("o1",
-                            ContractReferenceType(ContractType("Ow"), Owned(), false),
-                            ContractReferenceType(ContractType("Ow"), Unowned(), false)), 16)
-                          ::
-                          (UnusedOwnershipError("o2"), 16)
-                          ::
-                          (UnusedOwnershipError("o2"), 27)
-                          ::
-                          (MergeIncompatibleError("o1",
-                              ContractReferenceType(ContractType("Ow"), Owned(), false),
-                              ContractReferenceType(ContractType("Ow"), Unowned(), false)), 36)
-                          ::
-                          (UnusedOwnershipError("o2"), 36)
-                          ::
-            (VariableUndefinedError("x", null), 48)
+            (MergeIncompatibleError("o1",
+                ContractReferenceType(ContractType("Ow"), Owned(), false),
+                ContractReferenceType(ContractType("Ow"), Unowned(), false)), 16)
+                ::
+                (UnusedOwnershipError("o2"), 16)
+                ::
+                (UnusedOwnershipError("o2"), 27)
+                ::
+                (MergeIncompatibleError("o1",
+                    ContractReferenceType(ContractType("Ow"), Owned(), false),
+                    ContractReferenceType(ContractType("Ow"), Unowned(), false)), 36)
+                ::
+                (UnusedOwnershipError("o2"), 36)
+                ::
+                (VariableUndefinedError("x", null), 48)
                 ::
                 Nil)
     }
@@ -486,12 +486,12 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def ownershipTest(): Unit = {
         runTest("resources/tests/type_checker_tests/Ownership.obs",
-//                (TODO: https://github.com/mcoblenz/Obsidian/issues/134)
-//                (InvalidOwnershipTransfer(ReferenceIdentifier("p"), ContractReferenceType(ContractType("Prescription"), Unowned())), 16)
-//                ::
-                (SubtypingError(
-                    ContractReferenceType(ContractType("Prescription"), Unowned(), false),
-                    ContractReferenceType(ContractType("Prescription"), Owned(), false)), 16)
+            //                (TODO: https://github.com/mcoblenz/Obsidian/issues/134)
+            //                (InvalidOwnershipTransfer(ReferenceIdentifier("p"), ContractReferenceType(ContractType("Prescription"), Unowned())), 16)
+            //                ::
+            (SubtypingError(
+                ContractReferenceType(ContractType("Prescription"), Unowned(), false),
+                ContractReferenceType(ContractType("Prescription"), Owned(), false)), 16)
                 ::
                 Nil
         )
@@ -519,7 +519,7 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def transitionTest(): Unit = {
         runTest("resources/tests/type_checker_tests/Transitions.obs",
-                Nil
+            Nil
         )
     }
 
@@ -535,9 +535,9 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def shadowingTest(): Unit = {
         runTest("resources/tests/type_checker_tests/ForbiddenShadowing.obs",
-                (RepeatContractFields("x", 9, 2), 9)
-                    ::
-                    Nil
+            (RepeatContractFields("x", 9, 2), 9)
+                ::
+                Nil
         )
     }
 
@@ -563,46 +563,61 @@ class TypeCheckerTests extends JUnitSuite {
     @Test def argShadowingTest(): Unit = {
         runTest("resources/tests/type_checker_tests/ArgumentShadowing.obs",
             (ArgShadowingError("x", "t", 6), 10)
-              ::
-              Nil
+                ::
+                Nil
         )
     }
 
     @Test def multipleConstructorsTest(): Unit = {
         runTest("resources/tests/type_checker_tests/MultipleConstructors.obs",
             (MultipleConstructorsError("C"), 3)
-              ::
-              Nil
+                ::
+                Nil
         )
     }
 
     @Test def staticAssertsTest(): Unit = {
         runTest("resources/tests/type_checker_tests/StaticAsserts.obs",
             (StaticAssertInvalidState("C", "S3"), 6)
-              ::
-              (StaticAssertFailed(This(), Seq("S2"), StateType("C", Set("S1", "S2"), false)), 17)
-              ::
-              (StaticAssertFailed(ReferenceIdentifier("ow"), Seq("Unowned"), ContractReferenceType(ContractType("C"), Owned(), false)), 24)
-              ::
-              Nil
+                ::
+                (StaticAssertFailed(This(), Seq("S2"), StateType("C", Set("S1", "S2"), false)), 17)
+                ::
+                (StaticAssertFailed(ReferenceIdentifier("ow"), Seq("Unowned"), ContractReferenceType(ContractType("C"), Owned(), false)), 24)
+                ::
+                Nil
         )
     }
 
     @Test def typeSpecificationTest(): Unit = {
         runTest("resources/tests/type_checker_tests/TypeSpecification.obs",
-            (SubtypingError (StateType("C", Set("S3", "S2"), false),
-                             StateType("C", "S1", false)), 24)
-              ::
-              (ArgumentSpecificationError("a", "badChangeA",
-                  StateType("A", "Unavailable", false),
-                  StateType("A", "Available", false)), 51)
-              ::
-              (ArgumentSpecificationError("a", "badChangeA2",
-                  StateType("A", "Available", false),
-                  StateType("A", "Unavailable", false)), 56)
-              ::
-              Nil
+            (SubtypingError(StateType("C", Set("S3", "S2"), false),
+                StateType("C", "S1", false)), 24)
+                ::
+                (ArgumentSpecificationError("a", "badChangeA",
+                    StateType("A", "Unavailable", false),
+                    StateType("A", "Available", false)), 51)
+                ::
+                (ArgumentSpecificationError("a", "badChangeA2",
+                    StateType("A", "Available", false),
+                    StateType("A", "Unavailable", false)), 56)
+                ::
+                Nil
         )
-  }
+    }
 
+    @Test def readOnlyStateTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/ReadOnlyState.obs",
+            (TransitionNotAllowedError(), 11) ::
+                (ReceiverTypeIncompatibleError("changeStateShared",
+                    ContractReferenceType(ContractType("C"), ReadOnlyState(), false),
+                    ContractReferenceType(ContractType("C"), Shared(), false)), 39) ::
+                (ReceiverTypeIncompatibleError("changeStateOwned",
+                    ContractReferenceType(ContractType("C"), Shared(), false),
+                    ContractReferenceType(ContractType("C"), Owned(), false)), 42) ::
+                (ReceiverTypeIncompatibleError("changeStateStateSpecified",
+                    ContractReferenceType(ContractType("C"), Owned(), false),
+                    StateType("C", Set("S1"), false)), 45) ::
+                Nil
+        )
+    }
 }


### PR DESCRIPTION
Added support for "this" arguments that have no permission specified, in which case ReadOnlyState is inferred. "this" arguments that are missing are still treated as Shared. 

This change includes a few small improvements that I made along the way, including removal of the availableIn field from transactions and a fix to the parser to no longer use "THIS" as a contract name.