### PR TITLE
Make references inaccessible after used in invocation on a remote ins…

### DIFF
--- a/resources/tests/type_checker_tests/RemoteInstanceInvocation.obs
+++ b/resources/tests/type_checker_tests/RemoteInstanceInvocation.obs
@@ -1,0 +1,24 @@
+
+contract ExampleService {
+    transaction t(C@Shared c) {
+        c.setI(4);
+    }
+}
+
+contract C {
+    int i;
+
+    transaction setI(int j) {
+        i = j;
+    }
+}
+
+main contract ExampleClient {
+
+    transaction main(remote ExampleService@Shared service) {
+        C@Shared c = new C();
+        service.t(c);
+        // error, c cannot be used after used in invocation on remote instance
+        c.setI(5);
+    }
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -248,3 +248,7 @@ case class TransitionNotAllowedError() extends Error {
 case class ReceiverTypeIncompatibleError(transactionName: String, actualType: ObsidianType, expectedType: ObsidianType) extends Error {
     val msg: String = s"Cannot invoke $transactionName on a receiver of type $actualType; a receiver of type $expectedType is required."
 }
+
+case class UsedInRemoteInvoke(varName: String) extends Error {
+    val msg: String = s"Variable $varName cannot be used after passed as an argument to a remote invocation."
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
@@ -106,6 +106,8 @@ sealed trait ObsidianType extends HasLocation {
 
     def isResourceReference(contextContractTable: ContractTable) = false
 
+    var passedToRemote = false
+
 }
 
 /* int, bool, or string */

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -620,4 +620,12 @@ class TypeCheckerTests extends JUnitSuite {
                 Nil
         )
     }
+
+    @Test def remoteInstanceInvocationTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/RemoteInstanceInvocation.obs",
+            (UsedInRemoteInvoke("c"), 22)
+                ::
+                Nil
+        )
+    }
 }


### PR DESCRIPTION
…tance.

This is part 1 of "Support Obsidian clients better."

It's probably not the best way, but I assume we don't really want this temporary solution to be the end goal.

Also looks like there is some merge conflicts. Hopefully I can resolve those. I noted that `updateReceiverTypeInContext` took an ObsidianType and then checked if it was a NonPrimitiveType, but we already did that in `handleInvocation` ...