### PR TITLE
Issue 176 and 179

### DIFF
--- a/resources/tests/type_checker_tests/Branching.obs
+++ b/resources/tests/type_checker_tests/Branching.obs
@@ -47,4 +47,12 @@ main contract C {
         }
         x = 3;
     }
+
+    transaction t5() returns int {
+        if (true) {
+            return 5;
+        } else {
+            throw;
+        }
+    }
 }

--- a/resources/tests/type_checker_tests/UnownedReference.obs
+++ b/resources/tests/type_checker_tests/UnownedReference.obs
@@ -1,0 +1,69 @@
+main contract C { }
+
+contract CWithState {
+    state S1;
+
+    CWithState@S1() {
+        ->S1;
+    }
+
+    transaction inS1(CWithState@S1 this) { }
+
+}
+
+contract UsesC {
+
+    transaction t() {
+        C@Owned cOwned = new C();
+        needsUnowned(cOwned);
+        [cOwned @ Owned];
+        needsOwned(cOwned);
+        [cOwned @ Unowned];
+
+        CWithState@S1 cS1 = new CWithState();
+        needsUnownedWithState(cS1);
+        [cS1 @ S1];
+        needsStateS1(cS1);
+        [cS1 @ Unowned];
+    }
+
+    transaction t2() {
+        C@Owned cOwned = new C();
+        needsShared(cOwned);
+        [cOwned @ Unowned];
+        needsUnowned(cOwned);
+        [cOwned @ Unowned];
+
+        CWithState@S1 cS1 = new CWithState();
+        needsSharedWithState(cS1);
+        [cS1 @ Unowned];
+        needsUnownedWithState(cS1);
+        [cS1 @ Unowned];
+    }
+
+    transaction needsUnowned(C@Unowned cUnowned) {
+        [cUnowned @ Unowned];
+    }
+
+    transaction needsOwned(C@Owned cOwned) {
+        [cOwned @ Owned];
+    }
+
+    transaction needsShared(C@Shared cShared) {
+        [cShared @ Shared];
+    }
+
+    transaction needsUnownedWithState(CWithState@Unowned cUnowned) {
+        [cUnowned @ Unowned];
+    }
+
+    transaction needsStateS1(CWithState@S1 arg) {
+        arg.inS1();
+    }
+
+    transaction needsSharedWithState(CWithState@Shared cShared) {
+        [cShared @ Shared];
+    }
+
+
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -774,7 +774,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
 
                 if (isSubtype(argType, specType).isDefined) {
-                    val err = ArgumentSubtypingError(decl.name, argType, specType)
+                    val err = ArgumentSubtypingError(decl.name, spec(i).varName, argType, specType)
                     errList = (ast, err)::errList
                 }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -356,16 +356,14 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             }
 
             // check arguments
-            val (argTypes, contextAfterArgs) = inferAndCheckExprs(decl, contextAfterReceiver, args)
-            val specList = (invokable.args, invokable)::Nil
+            val spec = invokable.args
+            val specList = (spec, invokable)::Nil
 
-            val (correctInvokable, calleeToCaller) =
-                checkArgs(e, name, contextAfterArgs, specList, receiver, argTypes) match {
-                    case None => return (BottomType(), contextAfterArgs)
+            val (contextAfterArgs, correctInvokable) =
+                checkArgs(e, contextAfterReceiver, specList, args) match {
+                    case None => return (BottomType(), contextAfterReceiver)
                     case Some(x) => x
                 }
-
-            val spec = correctInvokable.args
 
             val resultType = correctInvokable.retType match {
                 case None => UnitType()
@@ -514,20 +512,16 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
                  val ctTableOfConstructed = tableLookup.get
 
-
-                 val (argTypes, contextPrime) = inferAndCheckExprs(decl, context, args)
                  val constrSpecs = ctTableOfConstructed
                                     .constructors
                                     .map(constr => (constr.args, constr))
 
-                 // todo : should this have a receiver
-                 val result =
-                     checkArgs(e, s"constructor of $name", context, constrSpecs, This(), argTypes)
+                 val result = checkArgs(e, context, constrSpecs, args)
 
-                 val simpleType = result match {
+                 val (simpleType, contextPrime) = result match {
                      // Even if the args didn't check, we can still output a type
-                     case None => ContractReferenceType(ctTableOfConstructed.contractType, Owned(), false)
-                     case Some((constr, _)) => constr.resultType
+                     case None => (ContractReferenceType(ctTableOfConstructed.contractType, Owned(), false), context)
+                     case Some((cntxt, constr)) => (constr.asInstanceOf[Constructor].resultType, cntxt)
                  }
 
                  (simpleType, contextPrime)
@@ -568,22 +562,6 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     }
 
 
-    private def inferAndCheckExprs(
-                                    decl: InvokableDeclaration,
-                                    context: Context,
-                                    es: Seq[Expression]
-                                ): (Seq[(ObsidianType, Expression)], Context) = {
-        val types = new ListBuffer[(ObsidianType, Expression)]()
-        var contextPrime = context
-        for (e <- es) {
-            val (t, contextPrime2) =
-                inferAndCheckExpr(decl, contextPrime, e, true)
-            contextPrime = contextPrime2
-            types.append((t, e))
-        }
-        (types, contextPrime)
-    }
-
     /* returns true if the sequence of statements includes a return statement, or an if/else statement
      * where both branches have return statements, and false otherwise
      */
@@ -597,7 +575,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             }
 
             statement match {
-                case Return() | ReturnExpr(_) => hasRet = true
+                case Return() | ReturnExpr(_) | Throw() => hasRet = true
                 case IfThenElse(_, s1, s2) =>
                     hasRet = hasReturnStatement(tx, s1) && hasReturnStatement(tx, s2)
                 case _ => ()
@@ -762,96 +740,64 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         }
     }
 
-    /* Returns [Left(p.head)] where [p] is the head of the path if failure,
-     * otherwise [Right(t)] where [t] is the type from the perspective of the caller */
-    private def toCallerPoV(
-            calleeToCaller: Map[String, Expression],
-            tr: NonPrimitiveType): Either[(String, Expression), NonPrimitiveType] = {
-        Right(tr)
-    }
-
-    /* removes unnecessary instances of "parent" from a type: e.g. if [x : y.T1],
-     * then the type [x.parent.T2] is converted to [y.T2] */
-    private def fixSimpleType(context: Context, tr: NonPrimitiveType): NonPrimitiveType = {
-        tr match {
-            case _ => tr
-        }
-    }
-
-    /* returns [Left(errs)] if [spec] and [args] don't match,
-     * and returns [Right(mapping)] if they do, where [mapping] maps argument names
-     * (from the callee's PoV) to expressions (from the caller's PoV).
-     * This function is special in that it doesn't immediately call [logError], but
-     * rather returns a set of errors. This is because, even if checking for this
-     * particular spec fails, another spec may match. */
-    private def checkArgs(
+    // Returns [Left(errs)] if [spec] and [args] don't match, and returns [Right(context)] if they do.
+    // Typechecks the arguments, and transfers ownership unless the spec is Unowned
+    private def checkArgsWithSpec(
             ast: AST,
-            methName: String,
+            decl: InvokableDeclaration,
             context: Context,
             spec: Seq[VariableDeclWithSpec],
-            receiver: Expression,
-            args: Seq[(ObsidianType, Expression)]): Either[Seq[(AST, Error)], Map[String, Expression]] = {
+            args: Seq[Expression]): Either[Seq[(AST, Error)], Context] = {
 
+        var errList: List[(AST, Error)] = Nil
         val (specL, argsL) = (spec.length, args.length)
 
         if (specL != argsL) {
-            Left((ast, WrongArityError(specL, argsL, methName))::Nil)
+            val name = if (decl.isInstanceOf[Constructor]) s"constructor of ${decl.name}" else decl.name
+            Left((ast, WrongArityError(specL, argsL, name))::errList)
         } else {
 
-            // Make the mapping
-            var calleeToCaller = TreeMap[String, Expression]()
+            val specTypes = spec.map(_.typIn)
+
+            var contextAfterArgs = context
             for (i <- args.indices) {
-                calleeToCaller = calleeToCaller.updated(spec(i).varName, args(i)._2)
-            }
-            calleeToCaller = calleeToCaller.updated("this", receiver)
+                val arg = args(i)
+                val specType = specTypes(i)
 
-            val specCallerPoV: Seq[ObsidianType] = spec.map(arg => {
-                arg.typIn match {
-                    case prim: PrimitiveType => prim
-                    case np: NonPrimitiveType =>
-                        toCallerPoV(calleeToCaller, np) match {
-                            case Left((head, e)) =>
-                                return Left((ast, CannotConvertPathError(head, e, np))::Nil)
-                            case Right(trNew) => fixSimpleType(context, trNew)
-                        }
-                    case BottomType() => BottomType()
-                    case u@UnresolvedNonprimitiveType(_, _) => assert(false); u
-                }
-            })
+                val transferOwnership: Boolean =
+                    specType match {
+                        case np: NonPrimitiveType => np.permission != Unowned()
+                        case _ => true
+                    }
 
-            var errList: List[(AST, Error)] = Nil
-            for (i <- args.indices) {
-                val (argTypeCallerPoV, _) = args(i)
-                val specTypeCallerPoV = specCallerPoV(i)
+                val (argType, contextAfterArg) = inferAndCheckExpr(decl, contextAfterArgs, arg, transferOwnership)
 
-                if (isSubtype(argTypeCallerPoV, specTypeCallerPoV).isDefined) {
-                    val err = SubtypingError(argTypeCallerPoV, specTypeCallerPoV)
+
+                if (isSubtype(argType, specType).isDefined) {
+                    val err = ArgumentSubtypingError(decl.name, argType, specType)
                     errList = (ast, err)::errList
                 }
+
+                contextAfterArgs = contextAfterArg
             }
-            if (errList.isEmpty) Right(calleeToCaller)
+
+            if (errList.isEmpty) Right(contextAfterArgs)
             else Left(errList)
         }
     }
 
-    /* takes multiple declarations ([specs]) for a transaction/function/constructor,
-     * ensuring that at least one matches the argument types given in [args].
-     * [ast] and [methName] are passed in order to generate helpful errors.
-     * A member of [U] is attached to each spec to indicate which spec matches.
-     * The return value from the successful call to [checkArgs] is also returned */
-    private def checkArgs[U](
+    // checks the arguments based on possibly many specifications, such as multiple constructors
+    // logs all errors at the end
+    private def checkArgs(
             ast: AST,
-            methName: String,
             context: Context,
-            specs: Seq[(Seq[VariableDeclWithSpec], U)],
-            receiver: Expression,
-            args: Seq[(ObsidianType, Expression)]): Option[(U, Map[String, Expression])] = {
+            specs: Seq[(Seq[VariableDeclWithSpec], InvokableDeclaration)],
+            args: Seq[Expression]): Option[(Context, InvokableDeclaration)] = {
 
         var errs: List[(AST, Error)] = Nil
-        for ((spec, extraData) <- specs) {
-            checkArgs(ast, methName, context, spec, receiver, args) match {
-                case Right(calleeToCaller) =>
-                    return Some((extraData, calleeToCaller))
+        for ((spec, invokable) <- specs) {
+            checkArgsWithSpec(ast, invokable, context, spec, args) match {
+                case Right(context) => return Some((context, invokable))
                 case Left(newErrs) =>
                     errs = newErrs.toList ++ errs
             }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -257,6 +257,6 @@ case class InconsistentTypeAssignmentError(declaredType: ObsidianType, actualTyp
     val msg: String = s"Cannot assign a value of type $actualType to a variable of type $declaredType."
 }
 
-case class ArgumentSubtypingError(tName: String, t1: ObsidianType, t2: ObsidianType) extends Error {
-    val msg: String = s"Found type '$t1' as an argument to '$tName', but expected something of type '$t2'."
+case class ArgumentSubtypingError(tName: String, arg: String, t1: ObsidianType, t2: ObsidianType) extends Error {
+    val msg: String = s"Found type '$t1' as an argument to '$tName', but the argument '$arg' is expected something of type '$t2'."
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -256,3 +256,7 @@ case class InconsistentContractTypeError(declaredContractName: String, actualCon
 case class InconsistentTypeAssignmentError(declaredType: ObsidianType, actualType: ObsidianType) extends Error {
     val msg: String = s"Cannot assign a value of type $actualType to a variable of type $declaredType."
 }
+
+case class ArgumentSubtypingError(tName: String, t1: ObsidianType, t2: ObsidianType) extends Error {
+    val msg: String = s"Found type '$t1' as an argument to '$tName', but expected something of type '$t2'."
+}

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -211,7 +211,7 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (WrongArityError(1, 2, "a"), 19)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("a",
                     StringType(),
                     IntType()), 21)
                 ::
@@ -225,7 +225,7 @@ class TypeCheckerTests extends JUnitSuite {
                     ContractReferenceType(ContractType("OtherContract"), Shared(), false),
                     "anotherMethod"), 31)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("otherMethod",
                     StringType(),
                     IntType()), 33)
                 ::
@@ -256,11 +256,11 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (WrongArityError(0, 1, "constructor of Thing"), 37)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("Thing",
                     StringType(),
                     IntType()), 37)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("OtherThing",
                     StringType(),
                     IntType()), 37)
                 ::
@@ -270,13 +270,13 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (WrongArityError(1, 3, "constructor of Thing"), 39)
                 ::
-                (WrongArityError(1, 3, "constructor of Thing"), 39)
+                (WrongArityError(1, 3, "constructor of OtherThing"), 39)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("Thing",
                     IntType(),
                     BoolType()), 39)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("Thing",
                     IntType(),
                     StringType()), 39)
                 ::
@@ -460,7 +460,7 @@ class TypeCheckerTests extends JUnitSuite {
                         "money",
                         None)), 43)
                 ::
-                (SubtypingError(
+                (ArgumentSubtypingError("discardMoney",
                     ContractReferenceType(ContractType("Money"), Unowned(), false),
                     ContractReferenceType(ContractType("Money"), Owned(), false)),
                     56)
@@ -619,5 +619,9 @@ class TypeCheckerTests extends JUnitSuite {
             (InvalidInconsistentFieldType("c", StateType("C", Set("S2"), false), StateType("C", Set("S1"), false)), 24) ::
             Nil
         )
+    }
+
+    @Test def unownedReferenceTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/UnownedReference.obs", Nil)
     }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -211,7 +211,7 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (WrongArityError(1, 2, "a"), 19)
                 ::
-                (ArgumentSubtypingError("a",
+                (ArgumentSubtypingError("a", "x",
                     StringType(),
                     IntType()), 21)
                 ::
@@ -225,7 +225,7 @@ class TypeCheckerTests extends JUnitSuite {
                     ContractReferenceType(ContractType("OtherContract"), Shared(), false),
                     "anotherMethod"), 31)
                 ::
-                (ArgumentSubtypingError("otherMethod",
+                (ArgumentSubtypingError("otherMethod", "x",
                     StringType(),
                     IntType()), 33)
                 ::
@@ -256,11 +256,11 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (WrongArityError(0, 1, "constructor of Thing"), 37)
                 ::
-                (ArgumentSubtypingError("Thing",
+                (ArgumentSubtypingError("Thing", "x",
                     StringType(),
                     IntType()), 37)
                 ::
-                (ArgumentSubtypingError("OtherThing",
+                (ArgumentSubtypingError("OtherThing", "x",
                     StringType(),
                     IntType()), 37)
                 ::
@@ -272,11 +272,11 @@ class TypeCheckerTests extends JUnitSuite {
                 ::
                 (WrongArityError(1, 3, "constructor of OtherThing"), 39)
                 ::
-                (ArgumentSubtypingError("Thing",
+                (ArgumentSubtypingError("Thing", "z",
                     IntType(),
                     BoolType()), 39)
                 ::
-                (ArgumentSubtypingError("Thing",
+                (ArgumentSubtypingError("Thing", "y",
                     IntType(),
                     StringType()), 39)
                 ::
@@ -460,7 +460,7 @@ class TypeCheckerTests extends JUnitSuite {
                         "money",
                         None)), 43)
                 ::
-                (ArgumentSubtypingError("discardMoney",
+                (ArgumentSubtypingError("discardMoney", "m",
                     ContractReferenceType(ContractType("Money"), Unowned(), false),
                     ContractReferenceType(ContractType("Money"), Owned(), false)),
                     56)


### PR DESCRIPTION
Fixes the issue of invoking a transaction (or constructor) on an Owned reference and taking ownership, even if the transaction specifies that it only needs an Unowned reference. 

Also addresses `throw` as a return statement issue. 