### PR TITLE
Deleted settings since not needed in Gradle 5.2.1, and build Runtime …

### DIFF
--- a/Obsidian_Runtime/build.gradle
+++ b/Obsidian_Runtime/build.gradle
@@ -22,4 +22,10 @@ publishing {
             from components.java
         }
     }
+    repositories {
+        //publish to local directory for GitHub hosting
+        maven {
+            url '../docs/repository'
+        }
+    }
 }

--- a/Obsidian_Runtime/settings.gradle
+++ b/Obsidian_Runtime/settings.gradle
@@ -1,1 +1,0 @@
-enableFeaturePreview('STABLE_PUBLISHING')

--- a/docs/repository/edu/cmu/cs/obsidian/runtime/0.1/runtime-0.1.pom
+++ b/docs/repository/edu/cmu/cs/obsidian/runtime/0.1/runtime-0.1.pom
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>edu.cmu.cs.obsidian</groupId>
+  <artifactId>runtime</artifactId>
+  <version>0.1</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20171018</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hyperledger.fabric-chaincode-java</groupId>
+      <artifactId>fabric-chaincode-shim</artifactId>
+      <version>1.+</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/docs/repository/edu/cmu/cs/obsidian/runtime/maven-metadata.xml
+++ b/docs/repository/edu/cmu/cs/obsidian/runtime/maven-metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>edu.cmu.cs.obsidian</groupId>
+  <artifactId>runtime</artifactId>
+  <versioning>
+    <release>0.1</release>
+    <versions>
+      <version>0.1</version>
+    </versions>
+    <lastUpdated>20190215005248</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
Publish the .jar straight into the /docs/repository file to make it accessible online to be used as a dependency in Fabric projects.