### PR TITLE
Fixes #206 by adding context for false branch in IfInState TypeChecker

### DIFF
--- a/resources/tests/type_checker_tests/InState.obs
+++ b/resources/tests/type_checker_tests/InState.obs
@@ -51,13 +51,13 @@ main contract InState {
              s.turnOff();
         }
 
-        // TODO: Make the type checker smart enough for this assertion to pass.
-        // [s @ Off];
+        [s @ Off];
 
         if (s in Off) {
              s.turnOn();
         }
 
+        // ERROR: s is On now, we know this specifically
         [s @ Owned];
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1488,8 +1488,14 @@ private def checkStatement(
                                     np.permission match {
                                         case Owned() =>
                                             val newType = StateType(np.contractName, Set(state._1), np.isRemote)
-                                            val typeFalse = StateType(np.contractName, allStates - state._1, np.isRemote)
-                                            (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
+                                            t match {
+                                                case StateType(_, specificStates, _) =>
+                                                    val typeFalse = StateType(np.contractName, specificStates - state._1, np.isRemote)
+                                                    (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
+                                                case _ =>
+                                                    val typeFalse = StateType(np.contractName, allStates - state._1, np.isRemote)
+                                                    (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
+                                            }
                                         case Unowned() => (contextPrime, contextPrime)
                                         case Shared() | Inferred() =>
                                             // If it's Inferred(), there's going to be another error later. For now, be optimistic.

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1446,15 +1446,35 @@ private def checkStatement(
                 (mergeContext(s, contextIfFalse, contextIfTrue), IfThenElse(eCond, checkedTrueStatements, checkedFalseStatements).setLoc(s))
 
             case IfInState(e, state, body1, body2) =>
+
                 val (t, contextPrime) = inferAndCheckExpr(decl, context, e, NoOwnershipConsumption())
+
+                val contractName = t match {
+                    case np: NonPrimitiveType =>
+                        np.contractName
+                    case _ =>
+                        if (!t.isBottom) {
+                            logError(e, SwitchError(t))
+                        }
+                        // There was previously some kind of error. Don't propagate it.
+                        return (contextPrime, s)
+                }
+
+                val contractTable = context.contractTable.lookupContract(contractName) match {
+                    case Some(table) => table
+                    case None => logError(e, SwitchError(t))
+                        return (contextPrime, s)
+                }
+
+                val allStates = contractTable.possibleStates
 
                 var resetOwnership: Option[(String, NonPrimitiveType)] = None
 
-                val contextForCheckingTrueBranch =
+                val (contextForCheckingTrueBranch, contextForCheckingFalseBranch) =
                     t match {
                         case p: PrimitiveType =>
                             logError(s, StateCheckOnPrimitiveError())
-                            contextPrime
+                            (contextPrime, contextPrime)
                         case np: NonPrimitiveType =>
                             val ident = e match {
                                 // If e is a variable, we might be able to put it in the context with the appropriate state.
@@ -1468,17 +1488,19 @@ private def checkStatement(
                                     np.permission match {
                                         case Owned() =>
                                             val newType = StateType(np.contractName, Set(state._1), np.isRemote)
-                                            contextPrime.updated(x, newType).updatedMakingVariableVal(x)
-                                        case Unowned() => contextPrime
+                                            val typeFalse = StateType(np.contractName, allStates - state._1, np.isRemote)
+                                            (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
+                                        case Unowned() => (contextPrime, contextPrime)
                                         case Shared() | Inferred() =>
                                             // If it's Inferred(), there's going to be another error later. For now, be optimistic.
                                             val newType = StateType(np.contractName, Set(state._1), np.isRemote)
                                             resetOwnership = Some((x, np))
-                                            contextPrime.updated(x, newType).updatedMakingVariableVal(x)
+                                            val typeFalse = StateType(np.contractName, allStates - state._1, np.isRemote)
+                                            (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
                                     }
-                                case None => contextPrime
+                                case None => (contextPrime, contextPrime)
                             }
-                        case BottomType() => contextPrime
+                        case BottomType() => (contextPrime, contextPrime)
                     }
 
                 val (trueContext, checkedTrueStatements) = checkStatementSequence(decl, contextForCheckingTrueBranch, body1)
@@ -1492,7 +1514,7 @@ private def checkStatement(
                     resetTrueContext,
                     contextForCheckingTrueBranch)
 
-                val (falseContext, checkedFalseStatements) = checkStatementSequence(decl, contextPrime, body2)
+                val (falseContext, checkedFalseStatements) = checkStatementSequence(decl, contextForCheckingFalseBranch, body2)
                 val contextIfFalse = pruneContext(s,
                     falseContext,
                     contextPrime)

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -660,6 +660,9 @@ class TypeCheckerTests extends JUnitSuite {
                 ContractReferenceType(ContractType("LightSwitch"), Unowned(), false),
                 StateType("LightSwitch", "Off", false)), 37) ::
             (StateCheckOnPrimitiveError(), 45) ::
-                 Nil)
+              (StaticAssertFailed(
+                ReferenceIdentifier("s"), Seq("Owned"),
+                StateType("LightSwitch", "On", false)), 61) ::
+              Nil)
     }
 }


### PR DESCRIPTION
We add a different context that expands the Owner states into all possible states and removes the one state we checked for in the true branch context. This fixes #206 