### PR TITLE
Add check for redundant if in state in typechecker and add tests

### DIFF
--- a/resources/tests/type_checker_tests/InState.obs
+++ b/resources/tests/type_checker_tests/InState.obs
@@ -54,10 +54,18 @@ main contract InState {
         [s @ Off];
 
         if (s in Off) {
+             // redundant if in state error since s is marked as Off line 54
              s.turnOn();
         }
 
         // ERROR: s is On now, we know this specifically
         [s @ Owned];
+    }
+
+    transaction t5(LightSwitch@Off >> On s) {
+        s.turnOn();
+        if (s in On) {
+            // error here since we know it will be on, redundant code
+        }
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1497,15 +1497,24 @@ private def checkStatement(
                                             val newType = StateType(np.contractName, Set(state._1), np.isRemote)
                                             t match {
                                                 case StateType(_, specificStates, _) =>
+                                                    if (specificStates.size == 1 && specificStates.contains(state._1)) {
+                                                        logError(e, StateCheckRedundant())
+                                                    }
                                                     val typeFalse = StateType(np.contractName, specificStates - state._1, np.isRemote)
                                                     (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
                                                 case _ =>
+                                                    if (allStates.size == 1 && allStates.contains(state._1)) {
+                                                        logError(e, StateCheckRedundant())
+                                                    }
                                                     val typeFalse = StateType(np.contractName, allStates - state._1, np.isRemote)
                                                     (contextPrime.updated(x, newType).updatedMakingVariableVal(x), contextPrime.updated(x, typeFalse).updatedMakingVariableVal(x))
                                             }
                                         case Unowned() => (contextPrime, contextPrime)
                                         case Shared() | Inferred() =>
                                             // If it's Inferred(), there's going to be another error later. For now, be optimistic.
+                                            if (allStates.size == 1 && allStates.contains(state._1)) {
+                                                logError(e, StateCheckRedundant())
+                                            }
                                             val newType = StateType(np.contractName, Set(state._1), np.isRemote)
                                             val typeFalse = StateType(np.contractName, allStates - state._1, np.isRemote)
                                             resetOwnership = Some((x, np))

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -317,6 +317,10 @@ case class StateCheckOnPrimitiveError() extends Error {
     val msg: String = s"Can't check the state of a primitive-type expression."
 }
 
+case class StateCheckRedundant() extends Error {
+    val msg: String = s"State check will always pass/fail. Remove redundant code."
+}
+
 case class InvalidValAssignmentError() extends Error {
     val msg: String = s"Can't reassign to variables that are formal parameters or which are used in a dynamic state check."
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -660,9 +660,12 @@ class TypeCheckerTests extends JUnitSuite {
                 ContractReferenceType(ContractType("LightSwitch"), Unowned(), false),
                 StateType("LightSwitch", "Off", false)), 37) ::
             (StateCheckOnPrimitiveError(), 45) ::
+              (StateCheckRedundant(), 56) ::
               (StaticAssertFailed(
                 ReferenceIdentifier("s"), Seq("Owned"),
-                StateType("LightSwitch", "On", false)), 61) ::
+                StateType("LightSwitch", "On", false)), 62) ::
+              (StateCheckRedundant(), 67) ::
               Nil)
+
     }
 }


### PR DESCRIPTION
Fixes #192 by checking if the only possible state to transition to is the one that is being checked on. If so, log an error. Also added test cases.