### PR TITLE
Fix setup for deploying chaincode to Fabric 

### DIFF
--- a/network-framework/channel-artifacts/README.md
+++ b/network-framework/channel-artifacts/README.md
@@ -1,0 +1,5 @@
+# About
+
+This directory contains the genesis block for the Fabric network and associated files.
+It exists in the Git repository because otherwise Fabric may create a directory which only root has permission to modify, which can cause the rest of setup process to fail.
+

--- a/network-framework/docker-compose-cli.yaml
+++ b/network-framework/docker-compose-cli.yaml
@@ -30,6 +30,8 @@ services:
     extends:
       file:  base/docker-compose-base.yaml
       service: peer0.org1.example.com
+    environment:
+      - GODEBUG=netdns=go
     networks:
       - byfn
 
@@ -38,6 +40,8 @@ services:
     extends:
       file:  base/docker-compose-base.yaml
       service: peer1.org1.example.com
+    environment:
+      - GODEBUG=netdns=go
     networks:
       - byfn
 
@@ -46,6 +50,8 @@ services:
     extends:
       file:  base/docker-compose-base.yaml
       service: peer0.org2.example.com
+    environment:
+      - GODEBUG=netdns=go
     networks:
       - byfn
 
@@ -54,6 +60,8 @@ services:
     extends:
       file:  base/docker-compose-base.yaml
       service: peer1.org2.example.com
+    environment:
+      - GODEBUG=netdns=go
     networks:
       - byfn
 

--- a/network-framework/up.sh
+++ b/network-framework/up.sh
@@ -7,7 +7,7 @@
 
 # prepending $PWD/../bin to PATH to ensure we are picking up the correct binaries
 # this may be commented out to resolve installed version of tools if desired
-export PATH=${PWD}/../fabric-samples/bin:${PWD}:$PATH
+export PATH=${PWD}/../bin:${PWD}:$PATH
 export FABRIC_CFG_PATH=${PWD}
 export VERBOSE=false
 
@@ -86,7 +86,7 @@ function checkPrereqs() {
 function networkUp() {
   checkPrereqs
   # replace the chaincode directory in the .evn file
-  sed -i .backup "s/^.*CHAINCODE_DIRECTORY=.*$/CHAINCODE_DIRECTORY=$CD/" .env
+  sed -i.backup "s/^.*CHAINCODE_DIRECTORY=.*$/CHAINCODE_DIRECTORY=$CD/" .env
   rm .env.backup
   # generate artifacts if they don't exist
   if [ ! -d "crypto-config" ]; then


### PR DESCRIPTION
The previous docker-compose-cli.yaml file had an issue which sometimes caused the peer nodes to crash (on my computer, Ubuntu 18.04.2 LTS) due to a DNS issue. This error can be fixed by forcing Go to always use the pure Go resolver (see discussion here: https://jira.hyperledger.org/browse/FAB-5822).

Additionally, it appears that installing Fabric no longer creates a fabric-samples directory, and instead puts the files directly into `.bin/`; `up.sh` has been updated accordingly.

Removing the space between the `-i` flag and `.backup` (see [here](https://github.com/mcoblenz/Obsidian/blob/afec0702830dca2ac6442aa8fd5d8d9b23b2b195/network-framework/up.sh#L89)) fixed an error (unrecognized command) on my computer.

Finally, adding the `channel-artifacts/` directory to the repository (via adding a `README.md` in the directory) causes the directory to be created with the correct permissions. Without this, Fabric will create the directory with root permissions on Ubuntu, both on my computer and the Travis build: see [this](https://travis-ci.org/mcoblenz/Obsidian/builds/538939160). Even though the build passes, in the log it says:

```
2019-05-29 20:45:58.461 UTC [common.tools.configtxgen] main -> FATA 008 Error on outputBlock: Error writing genesis block: open ./channel-artifacts/genesis.block: no such file or directory
```

This error has been resolved in the most recent build by adding the `channel-artifacts/` directory.