### PR TITLE
Fix grammatical mistake in type mismatch error message

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -288,7 +288,7 @@ case class InconsistentTypeAssignmentError(declaredType: ObsidianType, actualTyp
 }
 
 case class ArgumentSubtypingError(tName: String, arg: String, t1: ObsidianType, t2: ObsidianType) extends Error {
-    val msg: String = s"Found type '$t1' as an argument to '$tName', but the argument '$arg' is expected something of type '$t2'."
+    val msg: String = s"Found type '$t1' as an argument to '$tName', but the argument '$arg' expects something of type '$t2'."
 }
 
 case class FieldTypesDeclaredOnPublicTransactionError(tName: String) extends Error {

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Error.scala
@@ -288,7 +288,7 @@ case class InconsistentTypeAssignmentError(declaredType: ObsidianType, actualTyp
 }
 
 case class ArgumentSubtypingError(tName: String, arg: String, t1: ObsidianType, t2: ObsidianType) extends Error {
-    val msg: String = s"Found type '$t1' as an argument to '$tName', but the argument '$arg' expects something of type '$t2'."
+    val msg: String = s"Found type '$t1' as an argument to '$tName', but the argument '$arg' is expected to be something of type '$t2'."
 }
 
 case class FieldTypesDeclaredOnPublicTransactionError(tName: String) extends Error {


### PR DESCRIPTION
This pull request changes the message for mismatching types in transaction parameters from:

```
TestWrongType.obs 13.9: Found type 'C@S2' as an argument to 'f', but the argument 'x' is expected something of type 'C@S1'.
```

to:

```
TestWrongType.obs 13.9: Found type 'C@S2' as an argument to 'f', but the argument 'x' expects something of type 'C@S1'.
```

This closes #165.