### PR TITLE
Fix crash on redundant state check

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
@@ -116,7 +116,7 @@ case class StateType(contractName: String, stateNames: Set[String], override val
             return Yes()
         }
 
-        val stateIsAsset = contract match {
+        contract match {
             case None => No() // This will result in an error elsewhere.
             case Some(contractTable) =>
                 val statesAreAssets = stateNames.map((sn: String) =>
@@ -125,10 +125,15 @@ case class StateType(contractName: String, stateNames: Set[String], override val
                     case None => No()
                     case Some(stateTable) => if(stateTable.ast.isAsset) Yes() else No()
                 })
-                statesAreAssets.reduce((p1: Possibility, p2: Possibility) => if (p1 == p2) p1 else Maybe())
-        }
 
-        stateIsAsset
+
+                // If there's no possible states (i.e., statesAreAssets is empty), then there should be error elsewhere
+                if (statesAreAssets.isEmpty) {
+                    No()
+                } else {
+                    statesAreAssets.reduce((p1: Possibility, p2: Possibility) => if (p1 == p2) p1 else Maybe())
+                }
+        }
     }
 
     override def remoteType: NonPrimitiveType = StateType(contractName, stateNames, true)


### PR DESCRIPTION
The compiler used to crash on some redundant state checks, after this fix it will simply emit the error as originally intended. For example, compiling the following code:

```
main contract C { 
    state S1 {
        B@S1 b;
    }   

    C@S1() { ->S1; }

    transaction f(C@S1 this) returns int {
        if (b in S1) {
            return 1;
        } else {
            return 2;
        }
    }   
}

contract B { 
    state S1; 

    B@S1() { ->S1; }
}
```

gives:

```
Found 1 errors:
test.obs 9.13: State check will always pass/fail. Remove redundant code.
```

This closes #232.