### PR TITLE
Add support for mod operator

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGen.scala
@@ -2172,6 +2172,7 @@ class CodeGen (val target: Target, table: SymbolTable) {
             case Add(e1, e2) => recurse(e1).invoke("add").arg(recurse(e2))
             case Subtract(e1, e2) => recurse(e1).invoke("subtract").arg(recurse(e2))
             case Multiply(e1, e2) => recurse(e1).invoke("multiply").arg(recurse(e2))
+            case Mod(e1, e2) => recurse(e1).invoke("mod").arg(recurse(e2))
             case Divide(e1, e2) => recurse(e1).invoke("divide").arg(recurse(e2))
             case Negate(e) => recurse(e).invoke("negate")
             case Equals(e1, e2) => recurse(e1).invoke("equals").arg(recurse(e2))

--- a/src/main/scala/edu/cmu/cs/obsidian/lexer/Lexer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/lexer/Lexer.scala
@@ -80,6 +80,7 @@ object Lexer extends RegexParsers {
     private def plusP = """\+""".r ^^^  PlusT()
     private def starP = """\*""".r ^^^  StarT()
     private def forwardSlashP = """/""".r ^^^  ForwardSlashT()
+    private def percentP = """%""".r ^^^  PercentT()
     private def minusP = """-""".r ^^^  MinusT()
     private def lBraceP = """\{""".r ^^^  LBraceT()
     private def rBraceP = """\}""".r ^^^  RBraceT()
@@ -116,7 +117,7 @@ object Lexer extends RegexParsers {
         /* order is important here because some tokens contain the others */
         chevP | gtEqP | ltEqP | eqEqP | notEqP | rightArrowP | bigRightArrowP | ltP | gtP | eqP |
 
-        plusP | starP | forwardSlashP | minusP | coloncolonP | atP | lBracketP | rBracketP | pipeP | colonP
+        plusP | starP | forwardSlashP | percentP | minusP | coloncolonP | atP | lBracketP | rBracketP | pipeP | colonP
     )
 
     private def tokenParser: Parser[Seq[Token]] = phrase(rep1(positioned(oneToken)))

--- a/src/main/scala/edu/cmu/cs/obsidian/lexer/Token.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/lexer/Token.scala
@@ -77,6 +77,7 @@ case class PlusT() extends Token { override def toString: String = "+" }
 case class StarT() extends Token { override def toString: String = "*" }
 case class ForwardSlashT() extends Token { override def toString: String = "/" }
 case class MinusT() extends Token { override def toString: String = "-" }
+case class PercentT() extends Token { override def toString: String = "%" }
 case class AtT() extends Token { override def toString: String = "@" }
 case class LBracketT() extends Token { override def toString: String ="[" }
 case class RBracketT() extends Token { override def toString: String ="]" }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -65,6 +65,7 @@ case class Add(e1: Expression, e2: Expression) extends Expression
 case class Subtract(e1: Expression, e2: Expression) extends Expression
 case class Divide(e1: Expression, e2: Expression) extends Expression
 case class Multiply(e1: Expression, e2: Expression) extends Expression
+case class Mod(e1: Expression, e2: Expression) extends Expression
 case class Negate(e: Expression) extends Expression
 case class Equals(e1: Expression, e2: Expression) extends Expression
 case class GreaterThan(e1: Expression, e2: Expression) extends Expression

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -325,7 +325,8 @@ object Parser extends Parsers {
     private def parseAddition = parseBinary(PlusT(), Add.apply, parseSubtraction)
     private def parseSubtraction = parseBinary(MinusT(), Subtract.apply, parseMultiplication)
     private def parseMultiplication = parseBinary(StarT(), Multiply.apply, parseDivision)
-    private def parseDivision = parseBinary(ForwardSlashT(), Divide.apply, parseNot)
+    private def parseDivision = parseBinary(ForwardSlashT(), Divide.apply, parseMod)
+    private def parseMod = parseBinary(PercentT(), Mod.apply, parseNot)
     private def parseNot = parseUnary(NotT(), LogicalNegation.apply, parseUnaryMinus)
     private def parseUnaryMinus = parseUnary(MinusT(), Negate.apply, parseExprBottom)
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -618,6 +618,9 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
              case Multiply(e1: Expression, e2: Expression) =>
                  val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
                  (typ, con, Multiply(e1Prime, e2Prime).setLoc(e))
+             case Mod(e1: Expression, e2: Expression) =>
+                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
+                 (typ, con, Mod(e1Prime, e2Prime).setLoc(e))
              case Negate(e: Expression) =>
                  assertTypeEquality(e, IntType(), context)
              case Equals(e1: Expression, e2: Expression) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
@@ -139,6 +139,8 @@ class IdentityAstTransformer {
                 Divide(transformExpression(d.e1), transformExpression(d.e2)).setLoc(d)
             case m: Multiply =>
                 Multiply(transformExpression(m.e1), transformExpression(m.e2)).setLoc(m)
+            case mod: Mod =>
+                Mod(transformExpression(mod.e1), transformExpression(mod.e2)).setLoc(mod)
             case n: Negate =>
                 Negate(transformExpression(n.e)).setLoc(n)
             case eq: Equals =>

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/ParserTests.scala
@@ -264,4 +264,11 @@ class ParserTests extends JUnitSuite {
             """.stripMargin
         )
     }
+
+    @Test def parseModOperator() = {
+        shouldSucceed(
+            """
+              | main contract C { transaction f(int y) { int x = 1 % y; } }
+            """.stripMargin)
+    }
 }


### PR DESCRIPTION
We can now write things like `int x = a % b;`, which compiles to the existing `BigInteger` method `mod`.

This closes #238.