### PR TITLE
Remove erroneous return statement check on interface transactions

### DIFF
--- a/resources/tests/type_checker_tests/InterfaceWithReturn.obs
+++ b/resources/tests/type_checker_tests/InterfaceWithReturn.obs
@@ -1,0 +1,6 @@
+interface Test {
+    transaction f() returns int;
+}
+
+main contract C {}
+

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1853,22 +1853,27 @@ private def checkStatement(
 
         checkForUnusedStateInitializers(outputContext)
 
-        if (tx.retType.isDefined & !hasReturnStatement(tx, tx.body)) {
-            val ast =
-                if (tx.body.length > 0) {
-                    tx.body.last
+        lexicallyInsideOf.contract match {
+            case ObsidianContractImpl(modifiers, name, declarations, transitions, isInterface, sp) =>
+                // Don't need to check interface methods to make sure they return
+                // Use & instead of && to ensure that all conditions evaluate (hasReturn checks for multiple things)
+                if (!isInterface & tx.retType.isDefined & !hasReturnStatement(tx, tx.body)) {
+                    val ast =
+                        if (tx.body.nonEmpty) {
+                            tx.body.last
+                        } else {
+                            tx
+                        }
+                    logError(ast, MustReturnError(tx.name))
+                } else if (tx.retType.isEmpty) {
+                    // We check for unused ownership errors at each return; if there isn't guaranteed to be one at the end, check separately.
+                    // Every arg whose output type is owned should be owned at the end.
+                    val ownedArgs = tx.args.filter((arg: VariableDeclWithSpec) => arg.typOut.isOwned)
+                    val ownedArgNames = ownedArgs.map((arg: VariableDeclWithSpec) => arg.varName)
+                    checkForUnusedOwnershipErrors(tx, outputContext, Set("this") ++ ownedArgNames)
                 }
-                else {
-                    tx
-                }
-            logError(ast, MustReturnError(tx.name))
-        }
-        else if (!tx.retType.isDefined) {
-            // We check for unused ownership errors at each return; if there isn't guaranteed to be one at the end, check separately.
-            // Every arg whose output type is owned should be owned at the end.
-            val ownedArgs = tx.args.filter((arg: VariableDeclWithSpec) => arg.typOut.isOwned)
-            val ownedArgNames = ownedArgs.map((arg: VariableDeclWithSpec) => arg.varName)
-            checkForUnusedOwnershipErrors(tx, outputContext, Set("this") ++ ownedArgNames)
+
+            case JavaFFIContractImpl(name, interface, javaPath, sp, declarations) => ()
         }
 
         // Check to make sure all the field types are consistent with their declarations.

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1856,8 +1856,7 @@ private def checkStatement(
         lexicallyInsideOf.contract match {
             case ObsidianContractImpl(modifiers, name, declarations, transitions, isInterface, sp) =>
                 // Don't need to check interface methods to make sure they return
-                // Use & instead of && to ensure that all conditions evaluate (hasReturn checks for multiple things)
-                if (!isInterface & tx.retType.isDefined & !hasReturnStatement(tx, tx.body)) {
+                if (!hasReturnStatement(tx, tx.body) && !isInterface && tx.retType.isDefined) {
                     val ast =
                         if (tx.body.nonEmpty) {
                             tx.body.last

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -731,4 +731,8 @@ class TypeCheckerTests extends JUnitSuite {
         runTest("resources/tests/type_checker_tests/MultiConstrDistinguishable.obs",
             Nil)
     }
+
+    @Test def interfaceDoesntRequireReturnTest(): Unit = {
+        runTest("resources/tests/type_checker_tests/InterfaceWithReturn.obs", Nil)
+    }
 }


### PR DESCRIPTION
In the case of interfaces, we should not require that methods be checked for a return statement. This fix simply ignores this check if the contract containing the transaction is an interface.

This closes #240.