### PR TITLE
Enable chaincode upgrades without recreating network

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ To deploy and invoke the generated chaincode in a real Fabric environment, follo
 3. Run `./invoke.sh FUNCTION_NAME ARG1 ARG2 ...`, for instance: `./invoke.sh setS randomstring`
 4. After you are done, run `./down.sh` to kill and cleanup all Docker containers.
 
+If you wish to upgrade the chaincode on the network without destroying and recreating the entire network, you can run `./update.sh.
+This command uses the same path to the chaincode that you originally uploaded, so there is no need to pass any arguments.
 
 ###### Runtime .jar generation (for those working on Obsidian itself)
 If changes are made to the Obsidian_Runtime code, a new .jar has to be generated and published since the Fabric chaincode relies on it.
 To do so, go to the Obsidian_Runtime folder and run `gradle publish`.
 Then, push the modified .jar to the Git master branch, and it will be available online at `http://obsidian-lang.com/repository`
+

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To deploy and invoke the generated chaincode in a real Fabric environment, follo
 3. Run `./invoke.sh FUNCTION_NAME ARG1 ARG2 ...`, for instance: `./invoke.sh setS randomstring`
 4. After you are done, run `./down.sh` to kill and cleanup all Docker containers.
 
-If you wish to upgrade the chaincode on the network without destroying and recreating the entire network, you can run `./update.sh.
+If you wish to upgrade the chaincode on the network without destroying and recreating the entire network, you can run `./upgrade.sh`.
 This command uses the same path to the chaincode that you originally uploaded, so there is no need to pass any arguments.
 
 ###### Runtime .jar generation (for those working on Obsidian itself)

--- a/network-framework/scripts/install.sh
+++ b/network-framework/scripts/install.sh
@@ -2,7 +2,12 @@
 
 CHANNEL_NAME="mychannel"
 DELAY="3"
-LANGUAGE="java"
+: ${CHANNEL_NAME:="mychannel"}
+: ${DELAY:="3"}
+: ${LANGUAGE:="java"}
+: ${TIMEOUT:="10"}
+: ${VERBOSE:="false"}
+LANGUAGE="$(echo "$LANGUAGE" | tr [:upper:] [:lower:])"
 TIMEOUT="10"
 VERBOSE="false"
 
@@ -78,4 +83,3 @@ verifyResult $res "Chaincode installation on peer${PEER}.org${ORG} has failed"
 echo "===================== Chaincode is installed on peer${PEER}.org${ORG} ===================== "
 echo
 
-sleep $DELAY

--- a/network-framework/scripts/instantiate.sh
+++ b/network-framework/scripts/instantiate.sh
@@ -101,3 +101,5 @@ verifyResult $res "Chaincode instantiation on peer${PEER}.org${ORG} on channel '
 echo "===================== Chaincode is instantiated on peer${PEER}.org${ORG} on channel '$CHANNEL_NAME' ===================== "
 echo
 
+sleep $DELAY
+

--- a/network-framework/scripts/instantiate.sh
+++ b/network-framework/scripts/instantiate.sh
@@ -101,4 +101,3 @@ verifyResult $res "Chaincode instantiation on peer${PEER}.org${ORG} on channel '
 echo "===================== Chaincode is instantiated on peer${PEER}.org${ORG} on channel '$CHANNEL_NAME' ===================== "
 echo
 
-sleep $DELAY

--- a/network-framework/scripts/invoke.sh
+++ b/network-framework/scripts/invoke.sh
@@ -105,3 +105,4 @@ else
   echo "===================== Invoke transaction successful on $PEERS on channel '$CHANNEL_NAME' ===================== "
   echo
 fi
+

--- a/network-framework/scripts/upgrade.sh
+++ b/network-framework/scripts/upgrade.sh
@@ -97,5 +97,3 @@ verifyResult $res "Chaincode upgrade on peer${PEER}.org${ORG} has failed"
 echo "===================== Chaincode is upgraded on peer${PEER}.org${ORG} ===================== "
 echo
 
-sleep $DELAY
-

--- a/network-framework/scripts/upgrade.sh
+++ b/network-framework/scripts/upgrade.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+: ${CHANNEL_NAME:="mychannel"}
+: ${DELAY:="3"}
+: ${LANGUAGE:="java"}
+: ${TIMEOUT:="10"}
+: ${VERBOSE:="false"}
+LANGUAGE="$(echo "$LANGUAGE" | tr [:upper:] [:lower:])"
+
+PEER="$1"
+ORG="$2"
+INIT_ARGS="$3"
+VERSION=${4:-1.0}
+
+ORDERER_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem
+PEER0_ORG1_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt
+PEER0_ORG2_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt
+PEER0_ORG3_CA=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org3.example.com/peers/peer0.org3.example.com/tls/ca.crt
+
+SCRIPTS_PATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/scripts
+
+if [ -n "${INIT_ARGS}" ] ; then
+    if [ "${INIT_ARGS}" == "-" ] ; then
+        INIT='["init"]'
+    else
+        INIT='["init",'${INIT_ARGS}']'
+    fi
+else
+    INIT='["init"]'
+fi
+
+verifyResult() {
+  if [ $1 -ne 0 ]; then
+    echo "!!!!!!!!!!!!!!! "$2" !!!!!!!!!!!!!!!!"
+    echo "========= ERROR !!! FAILED to execute End-2-End Scenario ==========="
+    echo
+    exit 1
+  fi
+}
+
+setGlobals() {
+  PEER=$1
+  ORG=$2
+  if [ $ORG -eq 1 ]; then
+    CORE_PEER_LOCALMSPID="Org1MSP"
+    CORE_PEER_TLS_ROOTCERT_FILE=$PEER0_ORG1_CA
+    CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp
+    if [ $PEER -eq 0 ]; then
+      CORE_PEER_ADDRESS=peer0.org1.example.com:7051
+    else
+      CORE_PEER_ADDRESS=peer1.org1.example.com:7051
+    fi
+  elif [ $ORG -eq 2 ]; then
+    CORE_PEER_LOCALMSPID="Org2MSP"
+    CORE_PEER_TLS_ROOTCERT_FILE=$PEER0_ORG2_CA
+    CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org2.example.com/users/Admin@org2.example.com/msp
+    if [ $PEER -eq 0 ]; then
+      CORE_PEER_ADDRESS=peer0.org2.example.com:7051
+    else
+      CORE_PEER_ADDRESS=peer1.org2.example.com:7051
+    fi
+
+  elif [ $ORG -eq 3 ]; then
+    CORE_PEER_LOCALMSPID="Org3MSP"
+    CORE_PEER_TLS_ROOTCERT_FILE=$PEER0_ORG3_CA
+    CORE_PEER_MSPCONFIGPATH=/opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/peerOrganizations/org3.example.com/users/Admin@org3.example.com/msp
+    if [ $PEER -eq 0 ]; then
+      CORE_PEER_ADDRESS=peer0.org3.example.com:7051
+    else
+      CORE_PEER_ADDRESS=peer1.org3.example.com:7051
+    fi
+  else
+    echo "================== ERROR !!! ORG Unknown =================="
+  fi
+
+  if [ "$VERBOSE" == "true" ]; then
+    env | grep CORE
+  fi
+}
+
+# Install chaincode on all peers
+for org in 1 2; do
+    bash "$SCRIPTS_PATH/install.sh" 0 "$org" "$VERSION"
+done
+
+echo "===================== Upgrading chaincode on peer${PEER}.org${ORG} ===================== "
+setGlobals $PEER $ORG
+set -x
+peer chaincode upgrade -o orderer.example.com:7050 -C "$CHANNEL_NAME" -n mycc\
+    --tls "$CORE_PEER_TLS_ENABLED" --cafile "$ORDERER_CA" -l "${LANGUAGE}"\
+    -v "${VERSION}" -c "{\"Args\":${INIT}}" -p "${CC_SRC_PATH}"\
+    -P "AND ('Org1MSP.peer','Org2MSP.peer')" >&log.txt
+res=$?
+set +x
+cat log.txt
+verifyResult $res "Chaincode upgrade on peer${PEER}.org${ORG} has failed"
+echo "===================== Chaincode is upgraded on peer${PEER}.org${ORG} ===================== "
+echo
+
+sleep $DELAY
+

--- a/network-framework/scripts/upgrade.sh
+++ b/network-framework/scripts/upgrade.sh
@@ -97,3 +97,5 @@ verifyResult $res "Chaincode upgrade on peer${PEER}.org${ORG} has failed"
 echo "===================== Chaincode is upgraded on peer${PEER}.org${ORG} ===================== "
 echo
 
+sleep $DELAY
+

--- a/network-framework/upgrade.sh
+++ b/network-framework/upgrade.sh
@@ -53,5 +53,11 @@ if [[ -z "$VERSION" ]]; then
     VERSION="$(get_version)"
 fi
 
+CLI="$(docker ps -f name=cli -q)"
+if [ -z "$CLI" ]; then
+    echo "No fabric network found. Did you remember to start the network via 'up.sh -s PATH_TO_CHAINCODE'?"
+    exit 0
+fi
+
 docker exec cli scripts/upgrade.sh 0 1 "$INIT" "$VERSION"
 

--- a/network-framework/upgrade.sh
+++ b/network-framework/upgrade.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Print the usage message
+function printHelp() {
+  echo "Usage: "
+  echo "  upgrade.sh [-v <version>] [-n <init-args>]"
+  echo "    -n <arg> - argument to pass when instantiating the chaincode. Pass multiple -n arguments for multiple arguments."
+  echo "    -v <arg> - the new version of the chaincode after the upgrade"
+  echo "  upgrade.sh -h (print this message)"
+}
+
+INIT=""
+
+while getopts "h?c:t:d:f:s:l:i:v:n:" opt; do
+  case "$opt" in
+  h | \?)
+    printHelp
+    exit 0
+    ;;
+  v)
+    VERSION=$OPTARG
+    ;;
+  n)
+    if [ -n "$INIT" ]; then
+        INIT="${INIT},\"${OPTARG}\""
+    else
+        INIT="\"${OPTARG}\""
+    fi
+    ;;
+  esac
+done
+
+# Looks at all the versions installed on the peer, and picks a higher one
+# For example, if there are versions 1.0, 1.1, and 1.2, this function will pick 1.3
+get_version() {
+    docker exec cli peer chaincode list --installed | tail -1 | while read entry; do
+        version_num="$(echo "$entry" | cut -f2 -d"," | cut -f2 -d":" | xargs)"
+        new_version="$(echo "$version_num + 0.1" | bc -l)"
+        if [[ -z "$VERSION" ]]; then
+            VERSION="$new_version"
+        else
+            if [[ "$(echo "$new_version > $VERSION" | bc -l)" == "1" ]]; then
+                VERSION="$new_version"
+            fi
+        fi
+
+        echo "$VERSION"
+    done
+}
+
+# Choose a version if one wasn't passed in
+if [[ -z "$VERSION" ]]; then
+    VERSION="$(get_version)"
+fi
+
+docker exec cli scripts/upgrade.sh 0 1 "$INIT" "$VERSION"
+


### PR DESCRIPTION
This pull request adds a new script, `upgrade.sh`, which can be used to upgrade the chaincode on a running Fabric network (i.e., replace the old code without destroying and recreating the whole network). To use it, ensure that there is a running Fabric network, then run `./upgrade.sh`.

This brings the time to test code changes down to about 40 seconds. Not sure how to further improve, other than reducing the delay at the end of the scripts (would shave off about 9 more seconds), but as I'm not even sure why that's there, I don't want to mess with it too much.