### PR TITLE
Fix unwrapping of LogicalNegation in typechecker

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -605,7 +605,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                  val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, BoolType())
                  (typ, con, Disjunction(e1Prime, e2Prime).setLoc(e))
              case LogicalNegation(e: Expression) =>
-                 assertTypeEquality(e, BoolType(), context)
+                 val (typ, con, ePrime) = assertTypeEquality(e, BoolType(), context)
+                 (typ, con, LogicalNegation(ePrime).setLoc(e))
              case Add(e1: Expression, e2: Expression) =>
                  val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
                  (typ, con, Add(e1Prime, e2Prime).setLoc(e))


### PR DESCRIPTION
The bug was that, when typechecking LogicalNegation, the code simply asserted that the expression being negated was a boolean, without rewrapping it in the LogicalNegation.

This closes #251.