### PR TITLE
Fix duplicate field/method generation for constructors

### DIFF
--- a/resources/tests/compilerTests/MultipleConstructorGroup.obs
+++ b/resources/tests/compilerTests/MultipleConstructorGroup.obs
@@ -1,0 +1,16 @@
+contract B {
+    state S1;
+    state S2 {
+        int x;
+    }
+
+    B@S1() { ->S1; }
+
+    B@S2(int _x) {
+        ->S2(x = _x);
+    }
+}
+
+main contract MultipleConstructorGroup {
+}
+

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/CompilerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/CompilerTests.scala
@@ -69,4 +69,8 @@ class CompilerTests extends JUnitSuite {
   @Test def testFFI(): Unit = {
     testContract(contractName = "TestFFI")
   }
+
+  @Test def multipleConstructorGroup(): Unit = {
+    testContract(contractName = "MultipleConstructorGroup")
+  }
 }


### PR DESCRIPTION
This pull requests modifies the old constructor code generation by simply checking if the field `constructorReturnsOwnedReference` or related method exists before creating it, thereby preventing its duplication. 

This closes #253.