### PR TITLE
Improve build script to work from any directory

### DIFF
--- a/bin/obsidianc
+++ b/bin/obsidianc
@@ -1,3 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-java -jar target/scala-2.12/obsidianc.jar "$@" 
+bin_dir="$(cd "$(dirname $BASH_SOURCE)"; pwd)"
+root_dir="$bin_dir/.."
+export OBSIDIAN_COMPILER_DIR="$root_dir"
+
+obsidian_jar="$root_dir/target/scala-2.12/obsidianc.jar"
+
+if [[ ! -e "$obsidian_jar" ]]; then
+    (
+        cd "$root_dir"
+        sbt assembly
+    )
+
+    if [[ "$?" != "0" ]]; then
+        echo "Error building jar file, exiting."
+        exit 1
+    fi
+fi
+
+java -jar "$obsidian_jar" $@
+

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -193,7 +193,10 @@ object Main {
             if (compilerDir == null) {
                 // TODO: package up the compiler as a jar file and use a path relative to that
                 // Requiring the working dir to be the compiler's directory is inconvenient.
-                compilerDir = Paths.get("").toAbsolutePath().toString
+                compilerDir = System.getenv("OBSIDIAN_COMPILER_DIR")
+                if (compilerDir == null) {
+                    compilerDir = Paths.get("").toAbsolutePath().toString
+                }
             }
             val fabricPath = Paths.get(compilerDir, "fabric", "java")
             val buildPath = fabricPath.resolve("build.gradle")


### PR DESCRIPTION
Changes as discussed:

- Build script can work from any directory
- Will automatically build jar if it does not exist
- Can pass compiler flags in addition to file path now