### PR TITLE
Give error when asset state reference is lost

### DIFF
--- a/resources/tests/type_checker_tests/AssetStateTracking.obs
+++ b/resources/tests/type_checker_tests/AssetStateTracking.obs
@@ -1,0 +1,14 @@
+main contract AssetStateTracking {
+    asset state S1 {
+        int x;
+    }
+
+    AssetStateTracking@Owned() {
+        ->S1(x = 0);
+    }
+
+    transaction f() {
+        AssetStateTracking c = new AssetStateTracking();
+    }
+}
+

--- a/resources/tests/type_checker_tests/AssetStateTrackingOkay.obs
+++ b/resources/tests/type_checker_tests/AssetStateTrackingOkay.obs
@@ -1,0 +1,15 @@
+main contract AssetStateTracking {
+    asset state S1 {
+        int x;
+    }
+
+    AssetStateTracking@Owned() {
+        ->S1(x = 0);
+    }
+
+    transaction f() {
+        AssetStateTracking c = new AssetStateTracking();
+        disown c;
+    }
+}
+

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -922,7 +922,9 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     private def errorIfNotDisposable(variable: String, typ: ObsidianType, context: Context, ast: AST): Unit = {
         typ match {
             case t: NonPrimitiveType =>
-                if (t.isOwned && t.isAssetReference(context.contractTable) != No()) logError(ast, UnusedOwnershipError(variable))
+                if (t.isOwned && t.isAssetReference(context.contractTable) != No()) {
+                    logError(ast, UnusedOwnershipError(variable))
+                }
             case _ => ()
         }
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/ObsidianType.scala
@@ -217,12 +217,16 @@ sealed trait NonPrimitiveType extends ObsidianType {
     def topPermissionType = this
 
     override def isAssetReference(contextContractTable: ContractTable): Possibility = {
-        val contract = contextContractTable.lookupContract(contractName)
-        if (contract.isDefined && contract.get.contract.isAsset) {
-            Yes()
-        }
-        else {
-            No()
+        contextContractTable.lookupContract(contractName) match {
+            case Some(contract) => {
+                if (contract.contract.isAsset) {
+                    Yes()
+                } else {
+                    StateType(contractName, contract.possibleStates, isRemote).isAssetReference(contextContractTable)
+                }
+            }
+
+            case None => No()
         }
     }
 

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -735,4 +735,14 @@ class TypeCheckerTests extends JUnitSuite {
     @Test def interfaceDoesntRequireReturnTest(): Unit = {
         runTest("resources/tests/type_checker_tests/InterfaceWithReturn.obs", Nil)
     }
+
+    @Test def assetStateTrackingOwned(): Unit = {
+        runTest("resources/tests/type_checker_tests/AssetStateTracking.obs",
+            (UnusedOwnershipError("c"), 10) ::
+                Nil)
+    }
+
+    @Test def assetStateTrackingOwnedOkay(): Unit = {
+        runTest("resources/tests/type_checker_tests/AssetStateTrackingOkay.obs", Nil)
+    }
 }


### PR DESCRIPTION
Owned references to contracts that have asset states are now properly treated as though they may be assets.

This closes #256.