### PR TITLE
Give an error when passing owned references as arguments to transacti…

### DIFF
--- a/resources/tests/type_checker_tests/AllPermissions.obs
+++ b/resources/tests/type_checker_tests/AllPermissions.obs
@@ -8,9 +8,13 @@ main asset contract AllPermissions {
 
     transaction t3(AllPermissions @ Unowned this) {}
 
-    transaction t4(AllPermissions @ Owned >> Shared this) {}
+    transaction t4(AllPermissions @ Owned >> Shared this) {
+        disown this;
+    }
 
-    transaction t5(AllPermissions @ Owned >> Unowned this) {}
+    transaction t5(AllPermissions @ Owned >> Unowned this) {
+        disown this;
+    }
 
     transaction t6(AllPermissions @ Shared >> Owned this) {
         // Error; no way to make this typecheck.
@@ -163,5 +167,9 @@ main asset contract AllPermissions {
         x9.t5();
         x9.t9();
         [x9 @ Shared];
+    }
+
+    transaction loseOwnership(AllPermissions @ Owned >> Shared this) {
+        // Error: losing Owned reference to 'this'.
     }
 }

--- a/resources/tests/type_checker_tests/AllPermissions.obs
+++ b/resources/tests/type_checker_tests/AllPermissions.obs
@@ -69,4 +69,99 @@ main asset contract AllPermissions {
         [x9 @ Owned]; // Special exception!
         disown x9;
     }
+
+    transaction passShared() {
+        AllPermissions x1 = new AllPermissions();
+        x1.t4();
+        [x1 @ Shared];
+        x1.t1(); // ERROR
+        disown x1;
+
+        AllPermissions x2 = new AllPermissions();
+        x2.t4();
+        x2.t2();
+        [x2 @ Shared];
+
+        AllPermissions x3 = new AllPermissions();
+        x3.t4();
+        x3.t3(); // Special exception!
+        [x3 @ Shared];
+
+        AllPermissions x4 = new AllPermissions();
+        x4.t4();
+        x4.t4(); // ERROR
+        [x4 @ Shared];
+
+        AllPermissions x5 = new AllPermissions();
+        x5.t4();
+        x5.t5(); // ERROR
+        [x5 @ Unowned];
+
+        AllPermissions x6 = new AllPermissions();
+        x6.t4();
+        x6.t6();
+        [x6 @ Owned];
+        disown x6;
+
+        AllPermissions x7 = new AllPermissions();
+        x7.t4();
+        x7.t7();
+        [x7 @ Unowned];
+
+        AllPermissions x8 = new AllPermissions();
+        x8.t4();
+        x8.t8(); // Special exception!
+        [x8 @ Shared];
+
+        AllPermissions x9 = new AllPermissions();
+        x9.t4();
+        x9.t9();
+        [x9 @ Shared];
+    }
+
+    transaction passUnowned() {
+        AllPermissions x1 = new AllPermissions();
+        x1.t5();
+        [x1 @ Unowned];
+        x1.t1(); // ERROR
+        disown x1;
+
+        AllPermissions x2 = new AllPermissions();
+        x2.t5();
+        x2.t2(); // ERROR
+
+        AllPermissions x3 = new AllPermissions();
+        x3.t5();
+        x3.t3(); 
+        [x3 @ Unowned];
+
+        AllPermissions x4 = new AllPermissions();
+        x4.t5();
+        x4.t4(); // ERROR
+
+        AllPermissions x5 = new AllPermissions();
+        x5.t5();
+        x5.t5(); // ERROR
+
+        AllPermissions x6 = new AllPermissions();
+        x6.t5();
+        x6.t6(); // ERROR
+        [x6 @ Owned];
+        disown x6;
+
+        AllPermissions x7 = new AllPermissions();
+        x7.t5();
+        x7.t7(); // ERROR
+
+        AllPermissions x8 = new AllPermissions();
+        x8.t5();
+        x8.t8();
+        [x8 @ Owned];
+        disown x8;
+
+        AllPermissions x9 = new AllPermissions();
+        x9.t5();
+        x9.t9();
+        [x9 @ Shared];
+    }
 }

--- a/resources/tests/type_checker_tests/AllPermissions.obs
+++ b/resources/tests/type_checker_tests/AllPermissions.obs
@@ -1,0 +1,72 @@
+main asset contract AllPermissions {
+    AllPermissions @ Owned () {
+    }
+
+    transaction t1(AllPermissions @ Owned this) {}
+
+    transaction t2(AllPermissions @ Shared this) {}
+
+    transaction t3(AllPermissions @ Unowned this) {}
+
+    transaction t4(AllPermissions @ Owned >> Shared this) {}
+
+    transaction t5(AllPermissions @ Owned >> Unowned this) {}
+
+    transaction t6(AllPermissions @ Shared >> Owned this) {
+        // Error; no way to make this typecheck.
+    }
+
+    transaction t7(AllPermissions @ Shared >> Unowned this) {}
+
+    transaction t8(AllPermissions @ Unowned >> Owned this) {
+        // Error; no way to make this typecheck.
+    }
+    
+    transaction t9(AllPermissions @ Unowned >> Shared this) {
+        // Error; no way to make this typecheck.
+    }
+
+    transaction passOwned() {
+        AllPermissions x1 = new AllPermissions();
+        [x1 @ Owned];
+        x1.t1();
+        [x1 @ Owned];
+        disown x1;
+
+        AllPermissions x2 = new AllPermissions();
+        x2.t2(); // Error: losing ownership of an asset!
+        [x2 @ Shared];
+
+        AllPermissions x3 = new AllPermissions();
+        x3.t3();
+        [x3 @ Owned]; // Special exception!
+        disown x3;
+
+        AllPermissions x4 = new AllPermissions();
+        x4.t4();
+        [x4 @ Shared];
+
+        AllPermissions x5 = new AllPermissions();
+        x5.t5();
+        [x5 @ Unowned];
+
+        AllPermissions x6 = new AllPermissions();
+        x6.t6();
+        [x6 @ Owned];
+        disown x6;
+
+        AllPermissions x7 = new AllPermissions();
+        x7.t7(); // Error: losing ownership of an asset!
+        [x7 @ Unowned];
+
+        AllPermissions x8 = new AllPermissions();
+        x8.t8();
+        [x8 @ Owned];
+        disown x8;
+
+        AllPermissions x9 = new AllPermissions();
+        x9.t9();
+        [x9 @ Owned]; // Special exception!
+        disown x9;
+    }
+}

--- a/resources/tests/type_checker_tests/UnownedReference.obs
+++ b/resources/tests/type_checker_tests/UnownedReference.obs
@@ -32,13 +32,13 @@ contract UsesC {
         needsShared(c);
         [c @ Shared];
         needsUnowned(c);
-        [c @ Unowned];
+        [c @ Shared];
 
         CWithState cS1 = new CWithState();
         needsSharedWithState(cS1);
         [cS1 @ Shared];
         needsUnownedWithState(cS1);
-        [cS1 @ Unowned];
+        [cS1 @ Shared];
     }
 
     transaction needsUnowned(C@Unowned cUnowned) {

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -100,7 +100,11 @@ case class VariableDecl(typ: ObsidianType, varName: String) extends Statement
 case class VariableDeclWithInit(typ: ObsidianType, varName: String, e: Expression) extends Statement
 
 case class VariableDeclWithSpec(typIn: ObsidianType, typOut: ObsidianType, varName: String) extends Statement
-
+ {
+     override def toString: String = {
+         varName
+     }
+ }
 case class Return() extends Statement
 case class ReturnExpr(e: Expression) extends Statement
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -101,9 +101,7 @@ case class VariableDeclWithInit(typ: ObsidianType, varName: String, e: Expressio
 
 case class VariableDeclWithSpec(typIn: ObsidianType, typOut: ObsidianType, varName: String) extends Statement
  {
-     override def toString: String = {
-         varName
-     }
+     override def toString: String = varName
  }
 case class Return() extends Statement
 case class ReturnExpr(e: Expression) extends Statement

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1907,7 +1907,14 @@ private def checkStatement(
                     // Every arg whose output type is owned should be owned at the end.
                     val ownedArgs = tx.args.filter((arg: VariableDeclWithSpec) => arg.typOut.isOwned)
                     val ownedArgNames = ownedArgs.map((arg: VariableDeclWithSpec) => arg.varName)
-                    checkForUnusedOwnershipErrors(tx, outputContext, Set("this") ++ ownedArgNames)
+                    val ownedIdentifiers =
+                        if (tx.thisFinalType.isOwned) {
+                            ownedArgNames ++ Set("this")
+                        }
+                        else {
+                            ownedArgNames
+                        }
+                    checkForUnusedOwnershipErrors(tx, outputContext, ownedIdentifiers.toSet)
                 }
 
             case JavaFFIContractImpl(name, interface, javaPath, sp, declarations) => ()

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1095,7 +1095,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                                                finalType: NonPrimitiveType,
                                                referenceIdentifier: String,
                                                context: Context): Context = {
-        if (passedType.isOwned && initialType.permission == Unowned()) {
+        if ((passedType.isOwned || passedType.permission == Shared()) && initialType.permission == Unowned()) {
+            // Special exception: passing owned to Unowned or to Shared does not lose ownership.
             context
         }
         else {

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -776,6 +776,33 @@ class TypeCheckerTests extends JUnitSuite {
                     ContractReferenceType(ContractType("AllPermissions"), Shared(), false), false), 25) ::
                 (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x2")), 37) ::
                 (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x7")), 59) ::
+                (ReceiverTypeIncompatibleError("t1",
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 77) ::
+                (ReceiverTypeIncompatibleError("t4",
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 92) ::
+                (ReceiverTypeIncompatibleError("t5",
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 97) ::
+                (ReceiverTypeIncompatibleError("t1",
+                    ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 126) ::
+                (ReceiverTypeIncompatibleError("t2",
+                    ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 131) ::
+                (ReceiverTypeIncompatibleError("t4",
+                    ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 140) ::
+                (ReceiverTypeIncompatibleError("t5",
+                    ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 144) ::
+                (ReceiverTypeIncompatibleError("t6",
+                    ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 148) ::
+                (ReceiverTypeIncompatibleError("t7",
+                    ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 154) ::
                 Nil))
     }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -765,4 +765,17 @@ class TypeCheckerTests extends JUnitSuite {
                 (UnusedExpressionArgumentOwnershipError(LocalInvocation("returnOwnedAsset", Nil)), 65) ::
                 Nil))
     }
+
+    @Test def allPermissions(): Unit = {
+        runTest("resources/tests/type_checker_tests/AllPermissions.obs",
+            ((SubtypingError(ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
+                ContractReferenceType(ContractType("AllPermissions"), Owned(), false), false), 15) ::
+                (SubtypingError(ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false), false), 21) ::
+                (SubtypingError(ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false), false), 25) ::
+                (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x2")), 37) ::
+                (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x7")), 59) ::
+                Nil))
+    }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -769,40 +769,41 @@ class TypeCheckerTests extends JUnitSuite {
     @Test def allPermissions(): Unit = {
         runTest("resources/tests/type_checker_tests/AllPermissions.obs",
             ((SubtypingError(ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
-                ContractReferenceType(ContractType("AllPermissions"), Owned(), false), false), 15) ::
+                ContractReferenceType(ContractType("AllPermissions"), Owned(), false), false), 19) ::
                 (SubtypingError(ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false), false), 21) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false), false), 25) ::
                 (SubtypingError(ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false), false), 25) ::
-                (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x2")), 37) ::
-                (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x7")), 59) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false), false), 29) ::
+                (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x2")), 41) ::
+                (UnusedExpressionArgumentOwnershipError(ReferenceIdentifier("x7")), 63) ::
                 (ReceiverTypeIncompatibleError("t1",
                     ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 77) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 81) ::
                 (ReceiverTypeIncompatibleError("t4",
                     ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 92) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 96) ::
                 (ReceiverTypeIncompatibleError("t5",
                     ContractReferenceType(ContractType("AllPermissions"), Shared(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 97) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 101) ::
                 (ReceiverTypeIncompatibleError("t1",
                     ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 126) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 130) ::
                 (ReceiverTypeIncompatibleError("t2",
                     ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 131) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 135) ::
                 (ReceiverTypeIncompatibleError("t4",
                     ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 140) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 144) ::
                 (ReceiverTypeIncompatibleError("t5",
                     ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 144) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Owned(), false)), 148) ::
                 (ReceiverTypeIncompatibleError("t6",
                     ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 148) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 152) ::
                 (ReceiverTypeIncompatibleError("t7",
                     ContractReferenceType(ContractType("AllPermissions"), Unowned(), false),
-                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 154) ::
+                    ContractReferenceType(ContractType("AllPermissions"), Shared(), false)), 158) ::
+                (UnusedOwnershipError("this"), 172) ::
                 Nil))
     }
 }


### PR DESCRIPTION
…ons that are going to discard ownership.

In a future change, I'll add the remaining cases to AllPermissions.obs (passing shared and unowned arguments).