### PR TITLE
Fix obsidianc so it works with any Scala version

### DIFF
--- a/bin/obsidianc
+++ b/bin/obsidianc
@@ -4,9 +4,9 @@ bin_dir="$(cd "$(dirname $BASH_SOURCE)"; pwd)"
 root_dir="$bin_dir/.."
 export OBSIDIAN_COMPILER_DIR="$root_dir"
 
-obsidian_jar="$root_dir/target/scala-2.12/obsidianc.jar"
+obsidian_jar="$(find "$root_dir/target" -name "obsidianc.jar" | head -n1)"
 
-if [[ ! -e "$obsidian_jar" ]]; then
+if [[ -z "$obsidian_jar" ]]; then
     (
         cd "$root_dir"
         sbt assembly


### PR DESCRIPTION
The new script will search the `target/` directory for `obsidianc.jar`, and use the first one it finds. This approach, unlike hardcoding the version into the path, should work with any version of Scala.