### PR TITLE
adding translation for if-then-else, some code hoisting for clarity

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/Documents.Obsidian.iml" filepath="$PROJECT_DIR$/.idea/modules/Documents.Obsidian.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/Obsidian.iml" filepath="$PROJECT_DIR$/.idea/modules/Obsidian.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/Obsidian-build.iml" filepath="$PROJECT_DIR$/.idea/modules/Obsidian-build.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/Obsidian.project.Obsidian-build.iml" filepath="$PROJECT_DIR$/.idea/modules/Obsidian.project.Obsidian-build.iml" />

--- a/.idea/scala_compiler.xml
+++ b/.idea/scala_compiler.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ScalaCompilerConfiguration">
     <profile name="sbt 1" modules="obsidian_199" />
-    <profile name="sbt 2" modules="Obsidian">
+    <profile name="sbt 2" modules="Documents.Obsidian,Obsidian">
       <option name="deprecationWarnings" value="true" />
       <option name="uncheckedWarnings" value="true" />
     </profile>

--- a/resources/tests/GanacheTests/IfThenElse.json
+++ b/resources/tests/GanacheTests/IfThenElse.json
@@ -1,0 +1,6 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1
+}

--- a/resources/tests/GanacheTests/IfThenElse.obs
+++ b/resources/tests/GanacheTests/IfThenElse.obs
@@ -1,4 +1,4 @@
-main contract IfThenElse{
+main contract IfThenElse {
         int x;
         transaction ifthenelse() {
             if (true) {

--- a/resources/tests/GanacheTests/IfThenElse.obs
+++ b/resources/tests/GanacheTests/IfThenElse.obs
@@ -1,0 +1,11 @@
+main contract IfThenElse{
+        int x;
+        transaction ifthenelse() {
+            if (true) {
+	       x = 1;
+	    } else {
+	       x = 0;
+	    }
+            return;
+        }
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -257,18 +257,15 @@ object CodeGenYul extends CodeGenerator {
                 }
             case IfThenElse(scrutinee,pos,neg) =>
                 val scrutinee_yul : Seq[YulStatement] = translateExpr(scrutinee)
-                if(scrutinee_yul.length > 1){
+                if (scrutinee_yul.length > 1){
                     assert(false,"boolean expression in conditional translates to a sequence of expressons")
                     Seq()
                 }
                 scrutinee_yul.apply(0) match {
                     case ExpressionStatement(sye) =>
-                        //print("scrutinee explanded to: " + sye.toString())
                         val pos_yul = pos.flatMap(translateStatement)
                         val neg_yul = neg.flatMap(translateStatement)
-                        val ret = Seq(Switch(sye,Seq(Case(true_lit , Block(pos_yul)), Case(false_lit, Block(neg_yul)))))
-                        print ("expanded to: " + ret.toString())
-                        ret
+                        Seq(Switch(sye,Seq(Case(true_lit , Block(pos_yul)), Case(false_lit, Block(neg_yul)))))
                     case e =>
                         assert(false, "if statement built on non-expression: " + e.toString())
                         Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -6,6 +6,7 @@ import edu.cmu.cs.obsidian.CompilerOptions
 import edu.cmu.cs.obsidian.parser._
 import edu.cmu.cs.obsidian.Main.{findMainContract, findMainContractName}
 import edu.cmu.cs.obsidian.typecheck.ContractType
+import edu.cmu.cs.obsidian.codegen.Switch
 
 import scala.collection.immutable.Map
 
@@ -17,6 +18,10 @@ object CodeGenYul extends CodeGenerator {
     var stateIdx = -1    // whether or not there is a state
     var stateEnumMapping: Map[String, Int] = Map() // map from state name to an enum value
     var stateEnumCounter = 0  // counter indicating the next value to assign since we don't knon the total num of states
+
+    // some constants hoisted from below to avoid repeated code
+    val true_lit : Literal = Literal(LiteralKind.boolean, "true", "bool")
+    val false_lit : Literal = Literal(LiteralKind.boolean, "false", "bool")
 
     def gen(filename: String, srcDir: Path, outputPath: Path, protoDir: Path,
             options: CompilerOptions, checkedTable: SymbolTable, transformedTable: SymbolTable): Boolean = {
@@ -250,11 +255,27 @@ object CodeGenYul extends CodeGenerator {
                         assert(false, "TODO")
                         Seq()
                 }
-
-            case _ =>
-                assert(false, "TODO")
+            case IfThenElse(scrutinee,pos,neg) =>
+                val scrutinee_yul : Seq[YulStatement] = translateExpr(scrutinee)
+                if(scrutinee_yul.length > 1){
+                    assert(false,"boolean expression in conditional translates to a sequence of expressons")
+                    Seq()
+                }
+                scrutinee_yul.apply(0) match {
+                    case ExpressionStatement(sye) =>
+                        //print("scrutinee explanded to: " + sye.toString())
+                        val pos_yul = pos.flatMap(translateStatement)
+                        val neg_yul = neg.flatMap(translateStatement)
+                        val ret = Seq(Switch(sye,Seq(Case(true_lit , Block(pos_yul)), Case(false_lit, Block(neg_yul)))))
+                        print ("expanded to: " + ret.toString())
+                        ret
+                    case e =>
+                        assert(false, "if statement built on non-expression: " + e.toString())
+                        Seq()
+                }
+            case x =>
+                assert(false, "TODO: translateStatement for " + x.toString() + " is unimplemented")
                 Seq()
-
         }
     }
 
@@ -268,9 +289,9 @@ object CodeGenYul extends CodeGenerator {
                 // we compile to int, which is s256 in yul
                 Seq(ExpressionStatement(Literal(LiteralKind.number,n.toString(),"int")))
             case TrueLiteral() =>
-                Seq(ExpressionStatement(Literal(LiteralKind.boolean, "true", "bool")))
+                Seq(ExpressionStatement(true_lit))
             case FalseLiteral() =>
-                Seq(ExpressionStatement(Literal(LiteralKind.boolean, "false", "bool")))
+                Seq(ExpressionStatement(false_lit))
             case _ =>
                 assert(false, "TODO: translation of " + e.toString() + " is not implemented")
                 Seq() // TODO unimplemented


### PR DESCRIPTION
This implements translation of if-then-else to switch per #308, I think, but really shows that the problem in #310 is important to fix right away. Specifically, when translating the test case
```
main contract IfThenElse{
        int x;
        transaction ifthenelse() {
            if (true) {
	       x = 1;
	    } else {
	       x = 0;
	    }
            return;
        }
}
```
we actually produce the expansion
```
List(Switch(Literal(boolean,true,bool),List(Case(Literal(boolean,true,bool),Block(List(ExpressionStatement(FunctionCall(Identifier(sstore),List(Literal(number,0,int), Literal(number,1,int))))))), Case(Literal(boolean,false,bool),Block(List(ExpressionStatement(FunctionCall(Identifier(sstore),List(Literal(number,0,int), Literal(number,0,int))))))))))
```
but the written file is
```
object "IfThenElse" {
    code {
            mstore(64,128)
            return(0,0)
    }
    object "IfThenElse_deployed" {
        code {
            return(0,0)
                let selector := shr(224, calldataload(0))
                switch selector
                    case 0x70a08231 {
                    }
function ifthenelse(){
}
        }
    }
}
```
This not only drops the `mstore` command, but places the `return` above the code not below and omits the body of the function we produced entirely.