### PR TITLE
Update Travis link to use .com domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mcoblenz/Obsidian.svg?branch=master)](https://travis-ci.org/mcoblenz/Obsidian)
+[![Build Status](https://travis-ci.com/mcoblenz/Obsidian.svg?branch=master)](https://travis-ci.com/mcoblenz/Obsidian)
 [![Documentation Status](https://readthedocs.org/projects/obsidian/badge/?version=latest)](https://obsidian.readthedocs.io/en/latest/?badge=latest)
       
 


### PR DESCRIPTION
The Travis repository has already been migrated to the .com domain,
all that remains is to update this link.

In general, this change as announced by Travis in May 2018:
https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/