### PR TITLE
assignments, local variables, better tests, other bug fixes

### DIFF
--- a/resources/tests/GanacheTests/AssignLocalAdd.json
+++ b/resources/tests/GanacheTests/AssignLocalAdd.json
@@ -1,0 +1,6 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1
+}

--- a/resources/tests/GanacheTests/AssignLocalAdd.obs
+++ b/resources/tests/GanacheTests/AssignLocalAdd.obs
@@ -1,8 +1,8 @@
 main contract AssignLocalAdd{
-        transaction assignlocaladd() {
-           int x;
-           bool y;
-	   x = 5 + 12;
-           return;
-        }
+    transaction assignlocaladd() {
+        int x;
+        bool y;
+        x = 5 + 12;
+        return;
+    }
 }

--- a/resources/tests/GanacheTests/AssignLocalAdd.obs
+++ b/resources/tests/GanacheTests/AssignLocalAdd.obs
@@ -1,5 +1,5 @@
-main contract PrimOps{
-        transaction primops() {
+main contract AssignLocalAdd{
+        transaction assignlocaladd() {
            int x;
            bool y;
 	   x = 5 + 12;

--- a/resources/tests/GanacheTests/AssignLocalAdd.obs
+++ b/resources/tests/GanacheTests/AssignLocalAdd.obs
@@ -1,0 +1,8 @@
+main contract PrimOps{
+        transaction primops() {
+           int x;
+           bool y;
+	   x = 5 + 12;
+           return;
+        }
+}

--- a/resources/tests/GanacheTests/BoolLiteral.obs
+++ b/resources/tests/GanacheTests/BoolLiteral.obs
@@ -1,7 +1,6 @@
 main contract BoolLiteral{
-	 bool x;
-
 	 transaction BoolLiteral () {
+	     bool x;
 	     x = true;
 	     x = false;
 	 }

--- a/resources/tests/GanacheTests/If.json
+++ b/resources/tests/GanacheTests/If.json
@@ -1,0 +1,6 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1
+}

--- a/resources/tests/GanacheTests/If.obs
+++ b/resources/tests/GanacheTests/If.obs
@@ -1,0 +1,9 @@
+main contract If {
+        transaction iftest() {
+            int x;
+            if (true) {
+	       x = 1;
+	    }
+            return;
+        }
+}

--- a/resources/tests/GanacheTests/IfThenElse.obs
+++ b/resources/tests/GanacheTests/IfThenElse.obs
@@ -1,11 +1,11 @@
 main contract IfThenElse {
-        int x;
         transaction ifthenelse() {
+            int x;
             if (true) {
-	       x = 1;
-	    } else {
-	       x = 0;
-	    }
+	            x = 1;
+	        } else {
+	            x = 0;
+	        }
             return;
         }
 }

--- a/resources/tests/GanacheTests/IntConst.obs
+++ b/resources/tests/GanacheTests/IntConst.obs
@@ -1,6 +1,6 @@
 main contract IntConst{
-        int x;
         transaction intconst() {
+            int x;
             x = 4;
             return;
         }

--- a/resources/tests/GanacheTests/PrimOps.obs
+++ b/resources/tests/GanacheTests/PrimOps.obs
@@ -1,28 +1,30 @@
 main contract PrimOps{
-        int x;
-        bool y;
+           int x;
+           bool y;
 
         transaction primops() {
-            y = true && false;
-            y = true || false;
 
-            x = 4 + 4;
-            x = 4 - 4;
-            x = 4 / 4;
-            x = 4 * 4;
-            x = 4 % 4;
 
-            y = 1 == 2;
-            y = 1 != 2;
-            y = 3 > 4;
-            y = 3 >= 4;
-            y = 3 < 3;
-            y = 3 <= 3;
-            y = 3 != 3;
+           y = true && false;
+           y = true || false;
 
-            y = !y;
-            x = - x;
+           x = 4 + 4;
+           x = 4 - 4;
+           x = 4 / 4;
+           x = 4 * 4;
+           x = 4 % 4;
 
-            return;
+           y = 1 == 2;
+           y = 1 != 2;
+           y = 3 > 4;
+           y = 3 >= 4;
+           y = 3 < 3;
+           y = 3 <= 3;
+           y = 3 != 3;
+
+           y = !y;
+           x = - x;
+
+           return;
         }
 }

--- a/resources/tests/GanacheTests/PrimOps.obs
+++ b/resources/tests/GanacheTests/PrimOps.obs
@@ -1,9 +1,7 @@
 main contract PrimOps{
+        transaction primops() {
            int x;
            bool y;
-
-        transaction primops() {
-
 
            y = true && false;
            y = true || false;

--- a/resources/tests/GanacheTests/SimpleCall.obs
+++ b/resources/tests/GanacheTests/SimpleCall.obs
@@ -1,5 +1,6 @@
 main contract SimpleCall{
         int x;
+
         transaction updatex() {
             x = 4;
             return;

--- a/resources/tests/GanacheTests/SimpleCall.obs
+++ b/resources/tests/GanacheTests/SimpleCall.obs
@@ -1,13 +1,11 @@
 main contract SimpleCall{
-        int x;
-
-        transaction updatex() {
-            x = 4;
-            return;
+        transaction val() returns int {
+            return 4;
         }
         transaction main(){
+            int x;
             x = 9;
-            updatex();
+            x = val();
             return;
         }
 }

--- a/resources/tests/GanacheTests/SimpleCall.obs
+++ b/resources/tests/GanacheTests/SimpleCall.obs
@@ -2,10 +2,10 @@ main contract SimpleCall{
         transaction val() returns int {
             return 4;
         }
-        transaction main(){
+        transaction main() returns int{
             int x;
             x = 9;
             x = val();
-            return;
+            return x;
         }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -221,7 +221,10 @@ object CodeGenYul extends CodeGenerator {
                     case Some(retVarName) =>
                         val temp_id = nextTemp()
                         val e_yul = translateExpr(temp_id, e, contractName, checkedTable)
-                        decl_0exp(temp_id) +: e_yul :+ assign1(Identifier(retVarName), temp_id) :+ Leave()
+                        decl_0exp(temp_id) +:
+                            e_yul :+
+                            assign1(Identifier(retVarName), temp_id) :+
+                            Leave()
                     case None => assert(assertion = false, "error: returning an expression from a transaction without a return type")
                         Seq()
                 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -228,11 +228,12 @@ object CodeGenYul extends CodeGenerator {
             case Assignment(assignTo, e) =>
                 assignTo match {
                     case ReferenceIdentifier(x) =>
+                        //todo: easy optimization is to look at e; if it happens to be a literal we can save a temp.
                         val id = nextTemp()
                         val e_yul = translateExpr(id, e, contractName, checkedTable)
                         decl_0exp(id) +:
                             e_yul :+
-                            decl_1exp(Identifier(x), id)
+                            assign1(Identifier(x), id)
                     case _ =>
                         assert(assertion = false, "trying to assign to non-assignable: " + e.toString)
                         Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -257,8 +257,11 @@ object CodeGenYul extends CodeGenerator {
             case VariableDecl(typ, varName) =>
                 Seq(decl_0exp_t(Identifier(varName), typ))
             case VariableDeclWithInit(typ, varName, e) =>
-                assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
-                Seq()
+                val id = nextTemp()
+                val e_yul = translateExpr(id, e, contractName, checkedTable)
+                decl_0exp(id) +:
+                    e_yul :+
+                    decl_0exp_t_init(Identifier(varName), typ, id)
             case VariableDeclWithSpec(typIn, typOut, varName) =>
                 assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
                 Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable.Map
 object CodeGenYul extends CodeGenerator {
 
     // TODO improve this temporary symbol table
-    var tempSymbolTable: Map[String, Int] = Map() // map from field identifiers to index in storage
+    var tempSymbolTable: Map[String, Int] = Map() // map from field identifiers to index in storage //todo: deadcode?
     var tempTableIdx: Int = 0 // counter indicating the next available slot in the table
     var stateIdx: Int = -1 // whether or not there is a state
     var stateEnumMapping: Map[String, Int] = Map() // map from state name to an enum value
@@ -341,7 +341,7 @@ object CodeGenYul extends CodeGenerator {
             case e: AtomicExpression =>
                 e match {
                     case ReferenceIdentifier(x) =>
-                        Seq(assign1(retvar, apply("sload", intlit(tempSymbolTable(x)))))
+                        Seq(assign1(retvar, Identifier(x))) //todo: in general this will need to know to look in memory / storage / stack
                     case NumLiteral(n) =>
                         Seq(assign1(retvar, intlit(n)))
                     case StringLiteral(value) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -229,19 +229,13 @@ object CodeGenYul extends CodeGenerator {
             case Assignment(assignTo, e) =>
                 assignTo match {
                     case ReferenceIdentifier(x) =>
-                        val kind: LiteralKind = e match {
-                            case NumLiteral(_) => LiteralKind.number
-                            case TrueLiteral() => LiteralKind.boolean
-                            case FalseLiteral() => LiteralKind.boolean
-                            case StringLiteral(_) => LiteralKind.string
-                            case _ =>
-                                assert(assertion = false, s"unimplemented assignment case ${assignTo.toString}")
-                                LiteralKind.number
-                        }
-                        Seq(ExpressionStatement(FunctionCall(Identifier("sstore"),
-                            Seq(intlit(tempSymbolTable(x)), Literal(kind, e.toString, kind.toString))))) //todo: this is likely wrong for strings
-                    case e =>
-                        assert(assertion = false, "TODO: translate assignment case" + e.toString)
+                        val id = nextTemp()
+                        val e_yul = translateExpr(id,e,contractName,checkedTable)
+                        decl_0exp(id) +:
+                            e_yul :+
+                            decl_1exp(Identifier(x), id)
+                    case _ =>
+                        assert(assertion = false, "trying to assign to non-assignable: " + e.toString)
                         Seq()
                 }
             case IfThenElse(scrutinee, pos, neg) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -1,7 +1,6 @@
 package edu.cmu.cs.obsidian.codegen
 
 import edu.cmu.cs.obsidian.CompilerOptions
-import edu.cmu.cs.obsidian.codegen.LiteralKind.LiteralKind
 
 import java.io.{File, FileWriter}
 import java.nio.file.{Files, Path, Paths}
@@ -230,7 +229,7 @@ object CodeGenYul extends CodeGenerator {
                 assignTo match {
                     case ReferenceIdentifier(x) =>
                         val id = nextTemp()
-                        val e_yul = translateExpr(id,e,contractName,checkedTable)
+                        val e_yul = translateExpr(id, e, contractName, checkedTable)
                         decl_0exp(id) +:
                             e_yul :+
                             decl_1exp(Identifier(x), id)
@@ -241,6 +240,7 @@ object CodeGenYul extends CodeGenerator {
             case IfThenElse(scrutinee, pos, neg) =>
                 val id = nextTemp()
                 val scrutinee_yul: Seq[YulStatement] = translateExpr(id, scrutinee, contractName, checkedTable)
+                // todo: why don't these recursive calls both get new temps? that's gotta be a bug
                 val pos_yul: Seq[YulStatement] = pos.flatMap(s => translateStatement(s, retVar, contractName, checkedTable))
                 val neg_yul: Seq[YulStatement] = neg.flatMap(s => translateStatement(s, retVar, contractName, checkedTable))
                 decl_0exp(id) +:
@@ -251,8 +251,7 @@ object CodeGenYul extends CodeGenerator {
                             Case(boollit(false), Block(neg_yul))))
             case e: Expression => translateExpr(nextTemp(), e, contractName, checkedTable)
             case VariableDecl(typ, varName) =>
-                assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
-                Seq()
+                Seq(decl_0exp_t(Identifier(varName), typ))
             case VariableDeclWithInit(typ, varName, e) =>
                 assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
                 Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -16,7 +16,6 @@ import scala.collection.immutable.Map
 object CodeGenYul extends CodeGenerator {
 
     // TODO improve this temporary symbol table
-    var tempSymbolTable: Map[String, Int] = Map() // map from field identifiers to index in storage //todo: deadcode?
     var tempTableIdx: Int = 0 // counter indicating the next available slot in the table
     var stateIdx: Int = -1 // whether or not there is a state
     var stateEnumMapping: Map[String, Int] = Map() // map from state name to an enum value
@@ -155,7 +154,6 @@ object CodeGenYul extends CodeGenerator {
     def translateField(f: Field): Seq[YulStatement] = {
         // Reserve a slot in the storage by assigning a index in the symbol table
         // since field declaration has not yet be assigned, there is no need to do sstore
-        tempSymbolTable += f.name -> tempTableIdx
         tempTableIdx += 1
         Seq() // TODO: do we really mean to always return the empty sequence?
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -278,9 +278,18 @@ object CodeGenYul extends CodeGenerator {
             case Revert(maybeExpr) =>
                 assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
                 Seq()
-            case If(eCond, s) =>
-                assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
-                Seq()
+            case If(scrutinee, s) =>
+                val id_scrutinee: Identifier = nextTemp()
+                val scrutinee_yul: Seq[YulStatement] = translateExpr(id_scrutinee, scrutinee, contractName, checkedTable)
+                val s_yul: Seq[YulStatement] =
+                    s.flatMap(s => {
+                        val id_s: Identifier = nextTemp()
+                        decl_0exp(id_s) +: translateStatement(s, Some(id_s.name), contractName, checkedTable)
+                    })
+
+                decl_0exp(id_scrutinee) +:
+                    scrutinee_yul :+
+                    edu.cmu.cs.obsidian.codegen.If(id_scrutinee, Block(s_yul))
             case IfInState(e, ePerm, typeState, s1, s2) =>
                 assert(assertion = false, s"TODO: translateStatement unimplemented for ${s.toString}")
                 Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -101,6 +101,7 @@ object Util {
       * initial value
       *
       * @param id the name of the variable to be declared
+      * @param t the type for id
       * @return the expression declaring the variable
       */
     def decl_0exp_t(id: Identifier, t: ObsidianType): VariableDeclaration =
@@ -110,6 +111,8 @@ object Util {
       * initial value
       *
       * @param id the name of the variable to be declared
+      * @param t the type for id
+      * @param e the expression of type t to which id will be bound
       * @return the expression declaring the variable
       */
     def decl_0exp_t_init(id: Identifier, t: ObsidianType, e: Expression): VariableDeclaration =

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -96,6 +96,15 @@ object Util {
       */
     def decl_0exp(id: Identifier): VariableDeclaration = VariableDeclaration(Seq((id, None)), None)
 
+    /**
+      * shorthand for building the yul expression that declares one variable with a type and no
+      * initial value
+      *
+      * @param id the name of the variable to be declared
+      * @return the expression declaring the variable
+      */
+    def decl_0exp_t(id: Identifier, t: ObsidianType): VariableDeclaration =
+        VariableDeclaration(Seq((id, Some(mapObsTypeToABI(t.baseTypeName)))), None)
 
     /**
       * shorthand for building the yul expression that declares a sequence (non-empty) of identifiers

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -105,7 +105,15 @@ object Util {
       */
     def decl_0exp_t(id: Identifier, t: ObsidianType): VariableDeclaration =
         VariableDeclaration(Seq((id, Some(mapObsTypeToABI(t.baseTypeName)))), None)
-
+    /**
+      * shorthand for building the yul expression that declares one variable with a type and no
+      * initial value
+      *
+      * @param id the name of the variable to be declared
+      * @return the expression declaring the variable
+      */
+    def decl_0exp_t_init(id: Identifier, t: ObsidianType, e: Expression): VariableDeclaration =
+        VariableDeclaration(Seq((id, Some(mapObsTypeToABI(t.baseTypeName)))), Some(e))
     /**
       * shorthand for building the yul expression that declares a sequence (non-empty) of identifiers
       * with an initial value but no typing information

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -102,10 +102,19 @@ case class Assignment(variableNames: Seq[Identifier], value: Expression) extends
 case class VariableDeclaration(variables: Seq[(Identifier, Option[String])], value: Option[Expression]) extends YulStatement {
     override def toString: String = {
         s"let ${
-            variables.map(v => v._1.name + (v._2 match {
-                case Some(t) => s" : $t"
-                case None => ""
-            })).mkString(", ")
+            variables.map(v => v._1.name
+                // todo:
+                // this code correctly adds type annotations to the output Yul, but as of
+                // Version: 0.8.1+commit.df193b15.Linux.g++ of solc, you get errors like
+                // "Error: "bool" is not a valid type (user defined types are not yet supported)."
+                // when you run that code through solc even though the spec says otherwise.
+/*
+                + (v._2 match {
+                    case Some(t) => s" : $t"
+                    case None => ""
+                })
+*/
+            ).mkString(", ")
         }" +
             (value match {
                 case Some(e) => s" := ${e.toString}"

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -108,12 +108,12 @@ case class VariableDeclaration(variables: Seq[(Identifier, Option[String])], val
                 // Version: 0.8.1+commit.df193b15.Linux.g++ of solc, you get errors like
                 // "Error: "bool" is not a valid type (user defined types are not yet supported)."
                 // when you run that code through solc even though the spec says otherwise.
-/*
-                + (v._2 match {
-                    case Some(t) => s" : $t"
-                    case None => ""
-                })
-*/
+                /*
+                                + (v._2 match {
+                                    case Some(t) => s" : $t"
+                                    case None => ""
+                                })
+                */
             ).mkString(", ")
         }" +
             (value match {


### PR DESCRIPTION
this PR includes:
* assigning to local variables
* string literals
* if statements without and else
* a bug fix for if-then-else
* fixing a bug that made it look like fields worked when they did not
* changing the test cases to use local variables not fields
* declaring local variables

this would at least partially address #328 and #320

we now also emit code for `PrimOps.obs` that looks plausible, but `solc` produces this error when run on it:
```
Exception while assembling: /solidity/libyul/backends/evm/EVMObjectCompiler.cpp(66): Throw in function void solidity::yul::EVMObjectCompiler::run(solidity::yul::Object&, bool)
Dynamic exception type: boost::wrapexcept<solidity::yul::StackTooDeepError>
std::exception::what: Variable x is 1 slot(s) too deep inside the stack.
[solidity::util::tag_comment*] = Variable x is 1 slot(s) too deep inside the stack.
```
which i do not understand; i've made a note on #313 to fix this, since i'm thinking of it as a testing issue.