### PR TITLE
reconfiguring travis for slightly shorter build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ install:
   - sbt ++$TRAVIS_SCALA_VERSION test # this actually builds Obsidian
 
 env:
-  - TEST_SUITE=tests
-  - TEST_SUITE=ganache_tests
+  - TEST_SUITE=tests.sh
+  - TEST_SUITE=ganache_tests.sh
 
 script: "bash travis_specific/$TEST_SUITE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ before_install:
   - ./travis_specific/install_ganache.sh
 
 install:
-  - |
-    # from https://github.com/sbt/sbt/releases:
-    # update this only when sbt-the-bash-script needs to be updated
-    export SBT_LAUNCHER=1.5.0
-    export SBT_OPTS="-Dfile.encoding=UTF-8"
-    curl -L --silent "https://github.com/sbt/sbt/releases/download/v$SBT_LAUNCHER/sbt-$SBT_LAUNCHER.tgz" > $HOME/sbt.tgz
-    tar zxf $HOME/sbt.tgz -C $HOME
-    sudo rm /usr/local/bin/sbt
-    sudo ln -s $HOME/sbt/bin/sbt /usr/local/bin/sbt
+#  - |
+#    # from https://github.com/sbt/sbt/releases:
+#    # update this only when sbt-the-bash-script needs to be updated
+#    export SBT_LAUNCHER=1.5.0
+#    export SBT_OPTS="-Dfile.encoding=UTF-8"
+#    curl -L --silent "https://github.com/sbt/sbt/releases/download/v$SBT_LAUNCHER/sbt-$SBT_LAUNCHER.tgz" > $HOME/sbt.tgz
+#    tar zxf $HOME/sbt.tgz -C $HOME
+#    sudo rm /usr/local/bin/sbt
+#    sudo ln -s $HOME/sbt/bin/sbt /usr/local/bin/sbt
   - gradle publish -b Obsidian_Runtime/build.gradle
   - sbt ++$TRAVIS_SCALA_VERSION assembly # this actually builds Obsidian
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,8 @@ before_install:
   - ./travis_specific/install_ganache.sh
 
 install:
-#  - |
-#    # from https://github.com/sbt/sbt/releases:
-#    # update this only when sbt-the-bash-script needs to be updated
-#    export SBT_LAUNCHER=1.5.0
-#    export SBT_OPTS="-Dfile.encoding=UTF-8"
-#    curl -L --silent "https://github.com/sbt/sbt/releases/download/v$SBT_LAUNCHER/sbt-$SBT_LAUNCHER.tgz" > $HOME/sbt.tgz
-#    tar zxf $HOME/sbt.tgz -C $HOME
-#    sudo rm /usr/local/bin/sbt
-#    sudo ln -s $HOME/sbt/bin/sbt /usr/local/bin/sbt
   - gradle publish -b Obsidian_Runtime/build.gradle
-  - sbt ++$TRAVIS_SCALA_VERSION assembly # this actually builds Obsidian
+  - sbt ++$TRAVIS_SCALA_VERSION assembly # this builds the Obsidian jar
 
 env:
   - TEST_SUITE=tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
      - 15.11.0
 
 jdk:
-  - oraclejdk13 ## as of 9 march 2021, up to jdk12 seems to work but 13/14/15 fail
+  - oraclejdk12 ## as of 9 march 2021, up to jdk12 seems to work but 13/14/15 fail
 
 before_install:
   - ./travis_specific/install-protobuf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
     sudo rm /usr/local/bin/sbt
     sudo ln -s $HOME/sbt/bin/sbt /usr/local/bin/sbt
   - gradle publish -b Obsidian_Runtime/build.gradle
-  - sbt ++$TRAVIS_SCALA_VERSION test # this actually builds Obsidian
+  - sbt ++$TRAVIS_SCALA_VERSION assembly # this actually builds Obsidian
 
 env:
   - TEST_SUITE=tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
      - 15.11.0
 
 jdk:
-  - oraclejdk12 ## as of 9 march 2021, up to jdk12 seems to work but 13/14/15 fail
+  - oraclejdk13 ## as of 9 march 2021, up to jdk12 seems to work but 13/14/15 fail
 
 before_install:
   - ./travis_specific/install-protobuf.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
   - TEST_SUITE=tests
   - TEST_SUITE=ganache_tests
 
-script: "bundle exec bash travis_specific/$TEST_SUITE"
+script: "bash travis_specific/$TEST_SUITE"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
   - TEST_SUITE=tests.sh
   - TEST_SUITE=ganache_tests.sh
 
-script: "bash travis_specific/$TEST_SUITE"
+script: "travis_specific/$TEST_SUITE"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,14 @@ install:
     tar zxf $HOME/sbt.tgz -C $HOME
     sudo rm /usr/local/bin/sbt
     sudo ln -s $HOME/sbt/bin/sbt /usr/local/bin/sbt
-
-script:
   - gradle publish -b Obsidian_Runtime/build.gradle
   - sbt ++$TRAVIS_SCALA_VERSION test # this actually builds Obsidian
-  - bash travis_specific/tests.sh
-  - bash travis_specific/ganache_tests.sh
+
+env:
+  - TEST_SUITE=tests
+  - TEST_SUITE=ganache_tests
+
+script: "bundle exec bash travis_specific/$TEST_SUITE"
 
 cache:
   directories:

--- a/travis_specific/ganache_tests.sh
+++ b/travis_specific/ganache_tests.sh
@@ -36,6 +36,19 @@ fi
 # keep track of which tests fail so that we can output that at the bottom of the log
 failed=()
 
+obsidian_jar="$(find target/scala* -name obsidianc.jar | head -n1)"
+
+if [[ -z "$obsidian_jar" ]]; then
+    (
+        sbt assembly
+    )
+
+    if [[ "$?" != "0" ]]; then
+        echo "Error building jar file, exiting."
+        exit 1
+    fi
+fi
+
 for test in "${tests[@]}"
 do
   echo "---------------------------------------------------------------"
@@ -68,16 +81,16 @@ do
   fi
 
   # compile the contract to yul, also creating the directory to work in, failing otherwise
-  if ! sbt "runMain edu.cmu.cs.obsidian.Main --yul resources/tests/GanacheTests/$NAME.obs"
+  if ! $(java -jar $obsidian_jar --yul resources/tests/GanacheTests/$NAME.obs)
   then
-      echo "$NAME test failed: sbt exited cannot compile obs to yul"
-      failed+=("$test [sbt]")
+      echo "$NAME test failed: cannot compile obs to yul"
+      failed+=("$test [compile obs to yul]")
       exit 1
   fi
 
   if [ ! -d "$NAME" ]; then
       echo "$NAME directory failed to get created"
-      failed+=("$test [directory]")
+      failed+=("$test [output directory]")
       exit 1
   fi
 

--- a/travis_specific/ganache_tests.sh
+++ b/travis_specific/ganache_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # note: this won't be set locally so either set it on your machine to make
 # sense or run this only via travis.
@@ -27,7 +27,7 @@ else
   tests=(resources/tests/GanacheTests/*.json)
 fi
 
-missing_json=$(comm -13 <(ls resources/tests/GanacheTests/*.json | xargs basename -s '.json') <(ls resources/tests/GanacheTests/*.obs | xargs basename -s '.obs'))
+missing_json=$(comm -13 <(ls resources/tests/GanacheTests/*.json | sort | xargs basename -s '.json') <(ls resources/tests/GanacheTests/*.obs | sort | xargs basename -s '.obs'))
 if [ "$missing_json" ]
 then
   echo "******** warning: some tests are defined but do not have json files and will not be run:"
@@ -44,7 +44,7 @@ if [[ -z "$obsidian_jar" ]]; then
     )
 
     if [[ "$?" != "0" ]]; then
-        echo "Error building jar file, exiting."
+        echo "Error building Obsidian jar file, exiting."
         exit 1
     fi
 fi

--- a/travis_specific/ganache_tests.sh
+++ b/travis_specific/ganache_tests.sh
@@ -2,7 +2,9 @@
 
 # note: this won't be set locally so either set it on your machine to make
 # sense or run this only via travis.
+echo $(pwd -P)
 cd "$TRAVIS_BUILD_DIR" || exit 1
+echo $(pwd -P)
 
 ANY_FAILURES=0
 


### PR DESCRIPTION
this breaks the ganache tests out into a separate job with Travis matrices, so it runs in parallel. this also removes a bit of a hack we needed to work around a known bug with Travis and sbt that has now been fixed, and the ganache tests now use the jar'ed up version of Obsidian instead of making a call to sbt on every test, which saves a few minutes of run time.

this is part of #335 but does not close it.