### PR TITLE
add support for tests that produce negative numbers

### DIFF
--- a/bin/2sc.py
+++ b/bin/2sc.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+import sys
+
+## takes a two's complement 256 as the only argument and returns it as a
+## decimal
+
+def twos_comp(val, bits):
+    """compute the 2's complement of int value val"""
+    if (val & (1 << (bits - 1))) != 0:
+        val = val - (1 << bits)
+    return val
+
+print(twos_comp(int(sys.argv[1],16),8*32))

--- a/resources/tests/GanacheTests/PrimOpsSubNeg.json
+++ b/resources/tests/GanacheTests/PrimOpsSubNeg.json
@@ -1,0 +1,8 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1,
+    "testexp" : "primopssubneg()",
+    "expected" : "-15"
+}

--- a/travis_specific/ganache_tests.sh
+++ b/travis_specific/ganache_tests.sh
@@ -309,10 +309,10 @@ do
         continue
     fi
 
-    # pull the result out of the JSON object, delete the quotes and leading 0x, and make it upper case
-    GOT=$(echo "$RESP" | jq '.result' | tr -d '"' | sed -e "s/^0x//" | tr '[:lower:]' '[:upper:]')
+    # pull the result out of the JSON object, removing the quotation marks
+    GOT=$(echo "$RESP" | jq '.result' | tr -d '"')
     # use BC to convert it to decimal
-    GOT_DEC=$(echo "obase=10; ibase=16;$GOT" | bc)
+    GOT_DEC=$(python ../bin/2sc.py "$GOT")
 
     # todo: extend JSON object with a decode field so that we can have expected values that aren't integers more easily
     if [ "$GOT_DEC" == "$EXPECTED" ]


### PR DESCRIPTION
this closes #338. it also updates the list of tests that are written but don't pass in https://github.com/mcoblenz/Obsidian/issues/335 and makes fixing the parser the only thing left to do for https://github.com/mcoblenz/Obsidian/issues/337.