### PR TITLE
Adding boolean state detector and refactoring

### DIFF
--- a/corpus_studies/solidity_state_study/slither_plugins/BoolGraphInferrer.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/BoolGraphInferrer.py
@@ -1,0 +1,209 @@
+from slither.core.expressions import *
+from slither.core.cfg.node import *
+from slither.core.declarations import *
+from slither.detectors.functions.modifier import is_revert
+from .Graph import Edge, TransitionGraph
+
+# Checks if the expression is either true or false.
+def expr_is_bool_val(exp: Expression) -> bool:
+    return isinstance(exp, Literal) and exp.value in ['true', 'false']
+
+# Checks if the expression is equal to the variable var.
+def expr_is_var(exp: Expression, var: Variable) -> bool:
+    return isinstance(exp, Identifier) and exp.value == var
+
+class BoolGraphInferrer:
+    def __init__(self, 
+                contract: Contract,
+                state_var: StateVariable):
+        self.contract = contract
+        self.state_var = state_var
+        self.all_states = {'true', 'false'}
+
+    def inferTransitionGraph(self) -> TransitionGraph:
+        # Find the variable constructor, if it exists (where fields are initialized when they are declared).
+        constructor_vars = next((f for f in self.contract.functions if f.is_constructor_variables), None)
+        # Find the contract's constructor, if it exists.
+        # A contract can have a most one constructor, not counting inherited constructors.
+        # For a contract C, we are looking for a function with canonical name "C.constructor()"
+        # or "C.C()", depending on the version of Solidity.
+        constructor = next((f for f in self.contract.functions if f.is_constructor and f.canonical_name.startswith(self.contract.name)), None)
+        initial_states = self.find_initial_states(constructor_vars, constructor)
+
+        graph = TransitionGraph({'true', 'false'}, initial_states)
+
+        for func in self.contract.functions:
+            #if not (func.is_constructor or func.is_constructor_variables):
+            if not (func.is_constructor or func.is_constructor_variables or func.view or func.pure):
+                edges = self.exploreFunction(func)
+                for edge in edges:
+                    graph.addEdge(edge.s_from, edge.s_to, edge.label)
+        return graph
+
+    def find_initial_states(self, constructor_vars, constructor) -> Set[str]:
+        initial_states = {'false'}
+        if constructor_vars is not None:
+            edges = self.exploreFunction(constructor_vars)
+            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
+        if constructor is not None:
+            edges = self.exploreFunction(constructor)
+            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
+        return initial_states
+
+    def exploreFunction(self, func: Function) -> List[Edge]:
+        self.edges = set()
+        self.func = func
+        if func.entry_point is not None:
+            self.exploreNode(func.entry_point, self.all_states, {None})
+            return list(self.edges)
+        else:
+            return [Edge(s,s,func) for s in self.all_states]
+
+    def completeCodePath(self, starting_states: Set[str], ending_states: Set[Optional[str]]):
+        for start in starting_states:
+            for end in ending_states:
+                if end is None: 
+                    # A value of none means the value of the state variable has not changed
+                    self.edges.add(Edge(start, start, self.func))
+                else:
+                    self.edges.add(Edge(start, end, self.func))
+
+    # Explore an execution path starting at the given node, maintaining the set of
+    # possible starting and ending states.
+    # Once we have reached the end of an execution path, call completeCodePath to add the 
+    # starting and ending states as edges to the graph.
+    def exploreNode(self, 
+                    node: Node, 
+                    starting_states: Set[str], 
+                    ending_states: Set[Optional[str]], 
+                    subs: Dict[Variable, Expression] = None,
+                    level: int = 0) -> Set[str]:
+        if subs is None: subs = {}
+        # print("Exploring node %s, function = %s" % (node, self.func.name))
+        new_starting_states = self.mergeInfo(node, starting_states, ending_states, subs, level)
+        new_ending_states = self.mergeEndingStates(node, ending_states, subs)
+        
+        if is_revert(node):
+            return set()
+
+        if len(node.sons) == 0:
+            if level == 0:
+                self.completeCodePath(new_starting_states, new_ending_states)
+            return new_starting_states
+        elif len(node.sons) == 1:
+            return self.exploreNode(node.sons[0], new_starting_states, new_ending_states, subs, level)
+        else:
+            # If we reach an if statement, add the condition/negated condition to the
+            # list of assumptions for the respective branches, refining the set of 
+            # possible starting states.
+            if node.type == NodeType.IF:
+                starting_states_true = new_starting_states & self.possibleStates(node.expression, subs)
+                res_true = self.exploreNode(node.sons[0], starting_states_true, new_ending_states, subs, level)
+                negated_exp = UnaryOperation(node.expression, UnaryOperationType.BANG)
+                starting_states_false = new_starting_states & self.possibleStates(negated_exp, subs)
+                res_false = self.exploreNode(node.sons[1], starting_states_false, new_ending_states, subs, level)
+                return res_true | res_false
+            elif node.type == NodeType.IFLOOP:
+                # Ignore loop body and go to ENDLOOP node
+                return self.exploreNode(node.son_false, new_starting_states, new_ending_states, subs, level)
+            else:
+                raise Exception("Unexpected node: %s" % node)
+                # TODO: Handle other node types
+        
+    # Given a node and a set of possible states, return a refined set of possible initial states
+    # If the node is a require/assert, return the set of states that can make the condition true
+    # If the node is a modifier call, return the preconditions for the function/modifier.
+    def mergeInfo(self, node: Node, starting_states: Set[str], ending_states: Set[Optional[str]], subs: Dict[Variable, Expression], level: int) -> Set[str]:
+        if node.contains_require_or_assert():
+            #require and assert both only have one argument.
+            states = self.possibleStates(node.expression.arguments[0], subs)
+            return starting_states & states
+        elif isinstance(node.expression, CallExpression) and \
+             isinstance(node.expression.called, Identifier) and \
+             isinstance(node.expression.called.value, Modifier):
+            func = node.expression.called.value
+            params = func.parameters
+            arguments = node.expression.arguments
+            assert(len(params) == len(arguments))
+            # may need to merge the two subs somehow
+            subs: Dict[LocalVariable, Expression] = dict(zip(params, arguments))
+            # print("Call %s: %s" % (func, [str(x) for x in arguments]))
+            return starting_states & self.exploreNode(func.entry_point, starting_states, ending_states, subs, level+1)
+        else:
+            return starting_states.copy()
+
+    # Look for expressions assigning a constant enum value to the state var.
+    # If the RHS of an assignment is not recognized to be a constant value, assume the variable could hold any value.
+    def mergeEndingStates(self, 
+                          node: Node, 
+                          ending_states: Set[Optional[str]], 
+                          subs: Dict[Variable, Expression]) -> Set[Optional[str]]:
+        if isinstance(node.expression, AssignmentOperation) and \
+           node.expression.type == AssignmentOperationType.ASSIGN and \
+           expr_is_var(node.expression.expression_left, self.state_var):
+            rhs = node.expression.expression_right
+            if expr_is_bool_val(rhs):
+                assert(isinstance(rhs, Literal))
+                return {rhs.value}
+            else:
+                return self.all_states
+        else:
+            return ending_states.copy()
+    
+    # Call the helper function _possibleStates, returning the set of all states if the result is None
+    def possibleStates(self, exp: Expression, subs: Optional[Dict[Variable, Expression]]) -> Set[str]:
+        states = self._possibleStates(exp, subs)
+        if states is not None:
+            return states
+        else:
+            return self.all_states
+
+    # Given an expression (and an optional list of argument values for modifiers),
+    # return a set of state values that will make the expression true, or None if
+    # the expression is not relevant.
+    # In particular, we look for expressions comparing the state var to a constant 
+    # enum value, or any boolean combination of such expressions.
+    def _possibleStates(self, exp: Expression, subs: Dict[Variable, Expression]) -> Optional[Set[str]]:
+        if subs is None: subs = {}
+
+        if expr_is_var(exp, self.state_var):
+            return {'true'}
+        elif isinstance(exp, TupleExpression):
+            return self._possibleStates(exp.expressions[0], subs)
+        elif isinstance(exp, UnaryOperation) and exp.type == UnaryOperationType.BANG: # !; Take complement
+            ret = self._possibleStates(exp.expression, subs)
+            if ret is None:
+                return None
+            else:
+                return self.all_states - ret
+        elif isinstance(exp, BinaryOperation):
+            if exp.type == BinaryOperationType.ANDAND or exp.type == BinaryOperationType.OROR:
+                left = self._possibleStates(exp.expression_left, subs)
+                right = self._possibleStates(exp.expression_right, subs)
+                if left is None:
+                    return right
+                elif right is None:
+                    return left
+                else:
+                    if exp.type == BinaryOperationType.ANDAND: # &&; Take intersection
+                        return left & right
+                    elif exp.type == BinaryOperationType.OROR: # ||: Take union
+                        return left | right
+            elif exp.type == BinaryOperationType.EQUAL or exp.type == BinaryOperationType.NOT_EQUAL:
+                exp_left = exp.expression_left
+                exp_right = exp.expression_right
+                # If the right expression is our state variable, swap left and right.
+                # This reduces the number of checks we have to do.
+                if expr_is_var(exp_right, self.state_var):
+                    exp_left, exp_right = exp_right, exp_left
+                if expr_is_var(exp_left, self.state_var):
+                    # Check if the RHS is either an enum value, or a variable which we know is a constant enum value (from the subs dictionary)
+                    if isinstance(exp_right, Identifier) and exp_right.value in subs:
+                        exp_right = subs[exp_right.value]
+                    # Check if exp_right is an bool value.
+                    if expr_is_bool_val(exp_right):
+                        if exp.type == BinaryOperationType.EQUAL:
+                            return {exp_right.value}
+                        elif exp.type == BinaryOperationType.NOT_EQUAL:
+                            return self.all_states - {exp_right.value}
+        return None

--- a/corpus_studies/solidity_state_study/slither_plugins/BoolGraphInferrer.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/BoolGraphInferrer.py
@@ -3,6 +3,7 @@ from slither.core.cfg.node import *
 from slither.core.declarations import *
 from slither.detectors.functions.modifier import is_revert
 from .Graph import Edge, TransitionGraph
+from .GraphInferrer import GraphInferrer
 
 # Checks if the expression is either true or false.
 def expr_is_bool_val(exp: Expression) -> bool:
@@ -12,132 +13,25 @@ def expr_is_bool_val(exp: Expression) -> bool:
 def expr_is_var(exp: Expression, var: Variable) -> bool:
     return isinstance(exp, Identifier) and exp.value == var
 
-class BoolGraphInferrer:
+class BoolGraphInferrer(GraphInferrer):
     def __init__(self, 
                 contract: Contract,
                 state_var: StateVariable):
-        self.contract = contract
-        self.state_var = state_var
-        self.all_states = {'true', 'false'}
+        super().__init__(contract, state_var)
 
-    def inferTransitionGraph(self) -> TransitionGraph:
-        # Find the variable constructor, if it exists (where fields are initialized when they are declared).
-        constructor_vars = next((f for f in self.contract.functions if f.is_constructor_variables), None)
-        # Find the contract's constructor, if it exists.
-        # A contract can have a most one constructor, not counting inherited constructors.
-        # For a contract C, we are looking for a function with canonical name "C.constructor()"
-        # or "C.C()", depending on the version of Solidity.
-        constructor = next((f for f in self.contract.functions if f.is_constructor and f.canonical_name.startswith(self.contract.name)), None)
-        initial_states = self.find_initial_states(constructor_vars, constructor)
+    @property
+    def all_states(self) -> Set[str]:
+        return {'true', 'false'}
 
-        graph = TransitionGraph({'true', 'false'}, initial_states)
+    @property
+    def uninitialized_state(self) -> str:
+        return 'false'
 
-        for func in self.contract.functions:
-            #if not (func.is_constructor or func.is_constructor_variables):
-            if not (func.is_constructor or func.is_constructor_variables or func.view or func.pure):
-                edges = self.exploreFunction(func)
-                for edge in edges:
-                    graph.addEdge(edge.s_from, edge.s_to, edge.label)
-        return graph
-
-    def find_initial_states(self, constructor_vars, constructor) -> Set[str]:
-        initial_states = {'false'}
-        if constructor_vars is not None:
-            edges = self.exploreFunction(constructor_vars)
-            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
-        if constructor is not None:
-            edges = self.exploreFunction(constructor)
-            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
-        return initial_states
-
-    def exploreFunction(self, func: Function) -> List[Edge]:
-        self.edges = set()
-        self.func = func
-        if func.entry_point is not None:
-            self.exploreNode(func.entry_point, self.all_states, {None})
-            return list(self.edges)
-        else:
-            return [Edge(s,s,func) for s in self.all_states]
-
-    def completeCodePath(self, starting_states: Set[str], ending_states: Set[Optional[str]]):
-        for start in starting_states:
-            for end in ending_states:
-                if end is None: 
-                    # A value of none means the value of the state variable has not changed
-                    self.edges.add(Edge(start, start, self.func))
-                else:
-                    self.edges.add(Edge(start, end, self.func))
-
-    # Explore an execution path starting at the given node, maintaining the set of
-    # possible starting and ending states.
-    # Once we have reached the end of an execution path, call completeCodePath to add the 
-    # starting and ending states as edges to the graph.
-    def exploreNode(self, 
-                    node: Node, 
-                    starting_states: Set[str], 
-                    ending_states: Set[Optional[str]], 
-                    subs: Dict[Variable, Expression] = None,
-                    level: int = 0) -> Set[str]:
-        if subs is None: subs = {}
-        # print("Exploring node %s, function = %s" % (node, self.func.name))
-        new_starting_states = self.mergeInfo(node, starting_states, ending_states, subs, level)
-        new_ending_states = self.mergeEndingStates(node, ending_states, subs)
-        
-        if is_revert(node):
-            return set()
-
-        if len(node.sons) == 0:
-            if level == 0:
-                self.completeCodePath(new_starting_states, new_ending_states)
-            return new_starting_states
-        elif len(node.sons) == 1:
-            return self.exploreNode(node.sons[0], new_starting_states, new_ending_states, subs, level)
-        else:
-            # If we reach an if statement, add the condition/negated condition to the
-            # list of assumptions for the respective branches, refining the set of 
-            # possible starting states.
-            if node.type == NodeType.IF:
-                starting_states_true = new_starting_states & self.possibleStates(node.expression, subs)
-                res_true = self.exploreNode(node.sons[0], starting_states_true, new_ending_states, subs, level)
-                negated_exp = UnaryOperation(node.expression, UnaryOperationType.BANG)
-                starting_states_false = new_starting_states & self.possibleStates(negated_exp, subs)
-                res_false = self.exploreNode(node.sons[1], starting_states_false, new_ending_states, subs, level)
-                return res_true | res_false
-            elif node.type == NodeType.IFLOOP:
-                # Ignore loop body and go to ENDLOOP node
-                return self.exploreNode(node.son_false, new_starting_states, new_ending_states, subs, level)
-            else:
-                raise Exception("Unexpected node: %s" % node)
-                # TODO: Handle other node types
-        
-    # Given a node and a set of possible states, return a refined set of possible initial states
-    # If the node is a require/assert, return the set of states that can make the condition true
-    # If the node is a modifier call, return the preconditions for the function/modifier.
-    def mergeInfo(self, node: Node, starting_states: Set[str], ending_states: Set[Optional[str]], subs: Dict[Variable, Expression], level: int) -> Set[str]:
-        if node.contains_require_or_assert():
-            #require and assert both only have one argument.
-            states = self.possibleStates(node.expression.arguments[0], subs)
-            return starting_states & states
-        elif isinstance(node.expression, CallExpression) and \
-             isinstance(node.expression.called, Identifier) and \
-             isinstance(node.expression.called.value, Modifier):
-            func = node.expression.called.value
-            params = func.parameters
-            arguments = node.expression.arguments
-            assert(len(params) == len(arguments))
-            # may need to merge the two subs somehow
-            subs: Dict[LocalVariable, Expression] = dict(zip(params, arguments))
-            # print("Call %s: %s" % (func, [str(x) for x in arguments]))
-            return starting_states & self.exploreNode(func.entry_point, starting_states, ending_states, subs, level+1)
-        else:
-            return starting_states.copy()
-
-    # Look for expressions assigning a constant enum value to the state var.
+    # Look for expressions assigning a constant boolean value to the state var.
     # If the RHS of an assignment is not recognized to be a constant value, assume the variable could hold any value.
     def mergeEndingStates(self, 
                           node: Node, 
-                          ending_states: Set[Optional[str]], 
-                          subs: Dict[Variable, Expression]) -> Set[Optional[str]]:
+                          ending_states: Set[Optional[str]]) -> Set[Optional[str]]:
         if isinstance(node.expression, AssignmentOperation) and \
            node.expression.type == AssignmentOperationType.ASSIGN and \
            expr_is_var(node.expression.expression_left, self.state_var):
@@ -149,20 +43,12 @@ class BoolGraphInferrer:
                 return self.all_states
         else:
             return ending_states.copy()
-    
-    # Call the helper function _possibleStates, returning the set of all states if the result is None
-    def possibleStates(self, exp: Expression, subs: Optional[Dict[Variable, Expression]]) -> Set[str]:
-        states = self._possibleStates(exp, subs)
-        if states is not None:
-            return states
-        else:
-            return self.all_states
 
     # Given an expression (and an optional list of argument values for modifiers),
     # return a set of state values that will make the expression true, or None if
     # the expression is not relevant.
     # In particular, we look for expressions comparing the state var to a constant 
-    # enum value, or any boolean combination of such expressions.
+    # boolean value, or any boolean combination of such expressions.
     def _possibleStates(self, exp: Expression, subs: Dict[Variable, Expression]) -> Optional[Set[str]]:
         if subs is None: subs = {}
 

--- a/corpus_studies/solidity_state_study/slither_plugins/EnumGraphInferrer.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/EnumGraphInferrer.py
@@ -3,123 +3,35 @@ from slither.core.cfg.node import *
 from slither.core.declarations import *
 from slither.detectors.functions.modifier import is_revert
 from .Graph import Edge, TransitionGraph
+from .GraphInferrer import GraphInferrer, expr_is_var
 
 # Checks if the expression is an enum constant of the type enum_type.
 def expr_is_enum_val(exp: Expression, enum_type: EnumContract) -> bool:
     return isinstance(exp, MemberAccess) and isinstance(exp.expression, Identifier) and \
         exp.expression.value == enum_type
 
-# Checks if the expression is equal to the variable var.
-def expr_is_var(exp: Expression, var: Variable) -> bool:
-    return isinstance(exp, Identifier) and exp.value == var
-
-class EnumGraphInferrer:
+class EnumGraphInferrer(GraphInferrer):
     def __init__(self, 
                 contract: Contract,
                 state_var: StateVariable, 
                 enum_type: EnumContract):
-        self.contract = contract
-        self.state_var = state_var
-        self.all_states = set(enum_type.values)
+        super().__init__(contract, state_var)
         self.enum_type = enum_type
 
-    def inferTransitionGraph(self) -> TransitionGraph:
-        # Find the variable constructor, if it exists (this is where fields are initialized when they are declared).
-        constructor_vars = next((f for f in self.contract.functions if f.is_constructor_variables), None)
-        # Find the contract's constructor, if it exists.
-        # A contract can have a most one constructor, not counting inherited constructors.
-        # For a contract C, we are looking for a function with canonical name "C.constructor()"
-        # or "C.C()", depending on the version of Solidity.
-        constructor = next((f for f in self.contract.functions if f.is_constructor and f.canonical_name.startswith(self.contract.name)), None)
-        initial_states = self.find_initial_states(constructor_vars, constructor)
+    @property
+    def all_states(self) -> Set[str]:
+        return set(self.enum_type.values)
 
-        graph = TransitionGraph(set(self.enum_type.values), initial_states)
-
-        for func in self.contract.functions:
-            if not (func.is_constructor or func.is_constructor_variables):
-                edges = self.inferEdgesFromFunction(func)
-                for edge in edges:
-                    graph.addEdge(edge.s_from, edge.s_to, edge.label)
-        return graph
-
-    def find_initial_states(self, constructor_vars, constructor) -> Set[str]:
-        initial_states = {self.enum_type.values[0]}
-        if constructor_vars is not None:
-            edges = self.inferEdgesFromFunction(constructor_vars)
-            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
-        if constructor is not None:
-            edges = self.inferEdgesFromFunction(constructor)
-            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
-        return initial_states
-
-    def inferEdgesFromFunction(self, func: Function) -> List[Edge]:
-        self.edges = set()
-        self.func = func
-        if func.entry_point is not None:
-            self.inferEdgesFromNode(func.entry_point, self.all_states, {None})
-            return list(self.edges)
-        else:
-            return [Edge(s,s,func) for s in self.all_states]
-
-    # Add edges to the graph from connecting the possible starting states to the possible ending states.
-    def addEdgesFromCodePath(self, 
-                             starting_states: Set[str], 
-                             ending_states: Set[Optional[str]]):
-        for start in starting_states:
-            for end in ending_states:
-                if end is None: 
-                    # A value of none means the value of the state variable has not changed
-                    self.edges.add(Edge(start, start, self.func))
-                else:
-                    self.edges.add(Edge(start, end, self.func))
-
-    # Explore an execution path starting at the given node, maintaining the set of
-    # possible starting and ending states.
-    # Once we have reached the end of an execution path, call addEdgesFromCodePath to add the 
-    # starting and ending states as edges to the graph.
-    def inferEdgesFromNode(self, 
-                    node: Node, 
-                    starting_states: Set[str], 
-                    ending_states: Set[Optional[str]], 
-                    subs: Dict[Variable, Expression] = None,
-                    level: int = 0) -> Set[str]:
-        if subs is None: subs = {}
-        new_starting_states = self.mergeInfo(node, starting_states, ending_states, subs, level)
-        new_ending_states = self.mergeEndingStates(node, ending_states)
-        
-        if is_revert(node):
-            return set()
-
-        if len(node.sons) == 0:
-            if level == 0:
-                self.addEdgesFromCodePath(new_starting_states, new_ending_states)
-            return new_starting_states
-        elif len(node.sons) == 1:
-            return self.inferEdgesFromNode(node.sons[0], new_starting_states, new_ending_states, subs, level)
-        else:
-            # If we reach an if statement, add the condition/negated condition to the
-            # list of assumptions for the respective branches, refining the set of 
-            # possible starting states.
-            if node.type == NodeType.IF:
-                starting_states_true = new_starting_states & self.possibleStates(node.expression, subs)
-                res_true = self.inferEdgesFromNode(node.sons[0], starting_states_true, new_ending_states, subs, level)
-                negated_exp = UnaryOperation(node.expression, UnaryOperationType.BANG)
-                starting_states_false = new_starting_states & self.possibleStates(negated_exp, subs)
-                res_false = self.inferEdgesFromNode(node.sons[1], starting_states_false, new_ending_states, subs, level)
-                return res_true | res_false
-            elif node.type == NodeType.IFLOOP:
-                # Ignore loop body and go to ENDLOOP node
-                return self.inferEdgesFromNode(node.son_false, new_starting_states, new_ending_states, subs, level)
-            else:
-                raise Exception("Unexpected node: %s" % node)
-                # TODO: Handle other node types
+    @property
+    def uninitialized_state(self) -> Set[str]:
+        return self.enum_type.values[0]
         
     # Given a node and a set of possible states, return a refined set of possible initial states
     # If the node is a require/assert, return the set of states that can make the condition true
     # If the node is a modifier call, return the preconditions for the function/modifier.
     def mergeInfo(self, 
                   node: Node, 
-                  starting_states: Set[str], 
+                  starting_states: Set[str],    
                   ending_states: Set[Optional[str]], 
                   subs: Dict[Variable, Expression], 
                   level: int) -> Set[str]:
@@ -155,14 +67,6 @@ class EnumGraphInferrer:
                 return self.all_states
         else:
             return ending_states.copy()
-    
-    # Call the helper function _possibleStates, returning the set of all states if the result is None
-    def possibleStates(self, exp: Expression, subs: Optional[Dict[Variable, Expression]]) -> Set[str]:
-        states = self._possibleStates(exp, subs)
-        if states is not None:
-            return states
-        else:
-            return self.all_states
 
     # Given an expression (and an optional list of argument values for modifiers),
     # return a set of state values that will make the expression true, or None if

--- a/corpus_studies/solidity_state_study/slither_plugins/EnumGraphInferrer.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/EnumGraphInferrer.py
@@ -23,33 +23,8 @@ class EnumGraphInferrer(GraphInferrer):
         return set(self.enum_type.values)
 
     @property
-    def uninitialized_state(self) -> Set[str]:
+    def uninitialized_state(self) -> str:
         return self.enum_type.values[0]
-        
-    # Given a node and a set of possible states, return a refined set of possible initial states
-    # If the node is a require/assert, return the set of states that can make the condition true
-    # If the node is a modifier call, return the preconditions for the function/modifier.
-    def mergeInfo(self, 
-                  node: Node, 
-                  starting_states: Set[str],    
-                  ending_states: Set[Optional[str]], 
-                  subs: Dict[Variable, Expression], 
-                  level: int) -> Set[str]:
-        if node.contains_require_or_assert():
-            #require and assert both only have one argument.
-            states = self.possibleStates(node.expression.arguments[0], subs)
-            return starting_states & states
-        elif isinstance(node.expression, CallExpression) and \
-             isinstance(node.expression.called, Identifier) and \
-             isinstance(node.expression.called.value, Modifier):
-            func = node.expression.called.value
-            params = func.parameters
-            arguments = node.expression.arguments
-            assert(len(params) == len(arguments))
-            subs: Dict[LocalVariable, Expression] = dict(zip(params, arguments))
-            return starting_states & self.inferEdgesFromNode(func.entry_point, starting_states, ending_states, subs, level+1)
-        else:
-            return starting_states.copy()
 
     # Look for expressions assigning a constant enum value to the state var.
     # If the RHS of an assignment is not recognized to be a constant value, assume the variable could hold any value.

--- a/corpus_studies/solidity_state_study/slither_plugins/GraphInferrer.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/GraphInferrer.py
@@ -1,0 +1,153 @@
+from abc import ABC, abstractmethod
+from slither.core.expressions import *
+from slither.core.cfg.node import *
+from slither.core.declarations import *
+from slither.detectors.functions.modifier import is_revert
+from .Graph import Edge, TransitionGraph
+
+# Checks if the expression is equal to the variable var.
+def expr_is_var(exp: Expression, var: Variable) -> bool:
+    return isinstance(exp, Identifier) and exp.value == var
+
+class GraphInferrer(ABC):
+    def __init__(self, 
+                contract: Contract,
+                state_var: StateVariable):
+        self.contract = contract
+        self.state_var = state_var
+    
+    @property
+    @abstractmethod
+    def all_states(self) -> Set[str]:
+        pass
+
+    @property
+    @abstractmethod
+    def uninitialized_state(self) -> str:
+        pass
+
+    def inferTransitionGraph(self) -> TransitionGraph:
+        # Find the variable constructor, if it exists (this is where fields are initialized when they are declared).
+        constructor_vars = next((f for f in self.contract.functions if f.is_constructor_variables), None)
+        # Find the contract's constructor, if it exists.
+        # A contract can have a most one constructor, not counting inherited constructors.
+        # For a contract C, we are looking for a function with canonical name "C.constructor()"
+        # or "C.C()", depending on the version of Solidity.
+        constructor = next((f for f in self.contract.functions if f.is_constructor and f.canonical_name.startswith(self.contract.name)), None)
+        initial_states = self.find_initial_states(constructor_vars, constructor)
+
+        graph = TransitionGraph(self.all_states, initial_states)
+
+        for func in self.contract.functions:
+            if not (func.is_constructor or func.is_constructor_variables):
+                edges = self.inferEdgesFromFunction(func)
+                for edge in edges:
+                    graph.addEdge(edge.s_from, edge.s_to, edge.label)
+        return graph
+
+    def find_initial_states(self, constructor_vars, constructor) -> Set[str]:
+        initial_states = {self.uninitialized_state}
+        if constructor_vars is not None:
+            edges = self.inferEdgesFromFunction(constructor_vars)
+            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
+        if constructor is not None:
+            edges = self.inferEdgesFromFunction(constructor)
+            initial_states = {edge.s_to for edge in edges if edge.s_from in initial_states}
+        return initial_states
+
+    def inferEdgesFromFunction(self, func: Function) -> List[Edge]:
+        self.edges = set()
+        self.func = func
+        if func.entry_point is not None:
+            self.inferEdgesFromNode(func.entry_point, self.all_states, {None})
+            return list(self.edges)
+        else:
+            return [Edge(s,s,func) for s in self.all_states]
+
+    # Add edges to the graph from connecting the possible starting states to the possible ending states.
+    def addEdgesFromCodePath(self, 
+                             starting_states: Set[str], 
+                             ending_states: Set[Optional[str]]):
+        for start in starting_states:
+            for end in ending_states:
+                if end is None: 
+                    # A value of none means the value of the state variable has not changed
+                    self.edges.add(Edge(start, start, self.func))
+                else:
+                    self.edges.add(Edge(start, end, self.func))
+
+    # Explore an execution path starting at the given node, maintaining the set of
+    # possible starting and ending states.
+    # Once we have reached the end of an execution path, call addEdgesFromCodePath to add the 
+    # starting and ending states as edges to the graph.
+    def inferEdgesFromNode(self, 
+                    node: Node, 
+                    starting_states: Set[str], 
+                    ending_states: Set[Optional[str]], 
+                    subs: Dict[Variable, Expression] = None,
+                    level: int = 0) -> Set[str]:
+        if subs is None: subs = {}
+        new_starting_states = self.mergeInfo(node, starting_states, ending_states, subs, level)
+        new_ending_states = self.mergeEndingStates(node, ending_states)
+        
+        if is_revert(node):
+            return set()
+
+        if len(node.sons) == 0:
+            if level == 0:
+                self.addEdgesFromCodePath(new_starting_states, new_ending_states)
+            return new_starting_states
+        elif len(node.sons) == 1:
+            return self.inferEdgesFromNode(node.sons[0], new_starting_states, new_ending_states, subs, level)
+        else:
+            # If we reach an if statement, add the condition/negated condition to the
+            # list of assumptions for the respective branches, refining the set of 
+            # possible starting states.
+            if node.type == NodeType.IF:
+                starting_states_true = new_starting_states & self.possibleStates(node.expression, subs)
+                res_true = self.inferEdgesFromNode(node.sons[0], starting_states_true, new_ending_states, subs, level)
+                negated_exp = UnaryOperation(node.expression, UnaryOperationType.BANG)
+                starting_states_false = new_starting_states & self.possibleStates(negated_exp, subs)
+                res_false = self.inferEdgesFromNode(node.sons[1], starting_states_false, new_ending_states, subs, level)
+                return res_true | res_false
+            elif node.type == NodeType.IFLOOP:
+                # Ignore loop body and go to ENDLOOP node
+                return self.inferEdgesFromNode(node.son_false, new_starting_states, new_ending_states, subs, level)
+            else:
+                raise Exception("Unexpected node: %s" % node)
+                # TODO: Handle other node types
+        
+    # Given a node and a set of possible states, return a refined set of possible initial states
+    # If the node is a require/assert, return the set of states that can make the condition true
+    # If the node is a modifier call, return the preconditions for the function/modifier.
+    @abstractmethod
+    def mergeInfo(self, 
+                  node: Node, 
+                  starting_states: Set[str], 
+                  ending_states: Set[Optional[str]], 
+                  subs: Dict[Variable, Expression], 
+                  level: int) -> Set[str]:
+        pass
+
+    # Look for expressions assigning a constant enum value to the state var.
+    # If the RHS of an assignment is not recognized to be a constant value, assume the variable could hold any value.
+    @abstractmethod
+    def mergeEndingStates(self, 
+                          node: Node, 
+                          ending_states: Set[Optional[str]]) -> Set[Optional[str]]:
+        pass
+    
+    # Call the helper function _possibleStates, returning the set of all states if the result is None
+    def possibleStates(self, exp: Expression, subs: Optional[Dict[Variable, Expression]]) -> Set[str]:
+        states = self._possibleStates(exp, subs)
+        if states is not None:
+            return states
+        else:
+            return self.all_states
+
+    # Given an expression (and an optional list of argument values for modifiers),
+    # return a set of state values that will make the expression true, or None if
+    # the expression is not relevant.
+    @abstractmethod
+    def _possibleStates(self, exp: Expression, subs: Dict[Variable, Expression]) -> Optional[Set[str]]:
+        pass

--- a/corpus_studies/solidity_state_study/slither_plugins/ImmutableChecker.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/ImmutableChecker.py
@@ -1,0 +1,17 @@
+from slither.core.expressions import *
+from slither.core.cfg.node import *
+from slither.core.declarations import *
+
+# Checks whether variables in a contract could be declared immutable
+# (i.e., if they are never written to outside of the constructor/when they are initialized)
+class ImmutableChecker:
+    def __init__(self, contract: Contract):
+        self.contract: Contract = contract
+        self.poss_immutable: Set[StateVariable] = set()
+        for var in contract.state_variables:
+            funcs = [func for func in contract.functions_and_modifiers if not func.is_constructor and not func.is_constructor_variables]
+            if all(var not in func.variables_written for func in funcs):
+                self.poss_immutable.add(var)
+
+    def could_be_immutable(self, var: StateVariable):
+        return var in self.poss_immutable

--- a/corpus_studies/solidity_state_study/slither_plugins/boolstate.py
+++ b/corpus_studies/solidity_state_study/slither_plugins/boolstate.py
@@ -1,57 +1,47 @@
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
-from .GraphStateDetector import GraphStateDetector, inferEnumTransitionGraph, enumStateInfo
+from .GraphStateDetector import *
 
 # Class implemented as a detector plugin for Slither. This detector detects,
 # for the given contracts, which contracts have an abstract state controlled
 # by a single enum value. It will report the states and transitions, and also
 # unreachable states and state variables which will never be used in a certain state.
-class EnumState(AbstractDetector):
+class BoolState(AbstractDetector):
 
     STATEFUL_MESSAGE = "%s is stateful\n"
 
     # Variables declared for use in Slither
-    ARGUMENT = 'enumstate'
+    ARGUMENT = 'boolstate'
     HELP = 'Help printed by slither'
     IMPACT = DetectorClassification.INFORMATIONAL
     CONFIDENCE = DetectorClassification.HIGH
 
-    WIKI = 'ENUM STATE CHECK'
+    WIKI = 'BOOL STATE CHECK'
 
-    WIKI_TITLE = 'Enum State'
-    WIKI_DESCRIPTION = "Detects if a contract's state is controlled by a single enum value"
+    WIKI_TITLE = 'Bool State'
+    WIKI_DESCRIPTION = "Detects if a contract's state is controlled by a boolean which is deactivated"
     WIKI_EXPLOIT_SCENARIO = '''
-    contract Foo {
-        enum State {A, B, C, D}
-        State public state;
+    contract Deactivation {
+        bool stopped;
         uint public x;
+        uint y;
         
         constructor() {
-            state = State.B;
-            x = 0;
+            x = 5;
         }
 
-        modifier inState(State s) {
-            require(state == s);
-            _;
+        function stop() public {
+            require(stopped == false);
+            stopped = true;
         }
 
-        function goToB() public {
-            require(state == State.A || state == State.C);
-            state = State.B;
-        }
-
-        function goToC() public inState(State.B) {
-            state = State.C;
+        function addToX() public {
+            require(!stopped);
+            y++;
+            x += y;
         }
     }
 
-    Here is the contract's transition graph:
-    A --> B <--> C
-
-    D
-
-    Initial state: B
-    Unreachable states: A, D
+    Here, the function addToX is deactivated, meaning that after stop() is called, addToX and the field y will never be used again.
     '''
 
     WIKI_RECOMMENDATION = 'This is just a check, it does not indicate an error'
@@ -61,11 +51,10 @@ class EnumState(AbstractDetector):
     def _detect(self):
         stateful_contracts = []
         for c in self.contracts:
-            inferGraph = inferEnumTransitionGraph(c)
-            if inferGraph is not None:
-                (state_var, graph) = inferGraph
-                message = enumStateInfo(c, state_var, graph)
-                
+            bool_vars = getBoolStateVars(c)
+            for state_var in bool_vars:
+                graph = inferBoolTransitionGraph(c, state_var)
+                message = formatBoolInfo(boolStateInfo(c, state_var, graph))
                 stateful_contracts.append(message)
 
         if stateful_contracts:

--- a/corpus_studies/solidity_state_study/slither_plugins/tests/bools/Deactivation1.sol
+++ b/corpus_studies/solidity_state_study/slither_plugins/tests/bools/Deactivation1.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3
+pragma solidity ^0.8.4;
+
+contract Deactivation {
+    bool stopped;
+    uint public x;
+    uint y;
+    
+    constructor() {
+        x = 5;
+    }
+
+    function stop() public {
+        require(stopped == false);
+        stopped = true;
+    }
+
+    function addToX() public {
+        require(!stopped);
+        y++;
+        x += y;
+    }
+}

--- a/corpus_studies/solidity_state_study/slither_plugins/tests/enums/BranchingStates3.sol
+++ b/corpus_studies/solidity_state_study/slither_plugins/tests/enums/BranchingStates3.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3
+pragma solidity ^0.8.4;
+
+contract Foo {
+    enum State {A, B, C}
+    State public state;
+    uint public x;
+    
+    constructor() {
+        state = State.C;
+        x = 0;
+    }
+
+    
+    //Should have an edge C --> A
+    function moveToA() public {
+        require(state == State.C);
+        if (true) {
+            state = State.A;
+        }
+        else {
+            revert();
+            //this assignment should be ignored
+            state = State.B;
+        }
+    }
+}

--- a/corpus_studies/solidity_state_study/slither_plugins/tests/enums/BranchingStates4.sol
+++ b/corpus_studies/solidity_state_study/slither_plugins/tests/enums/BranchingStates4.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3
+pragma solidity ^0.8.4;
+
+contract Foo {
+    enum State {A, B, C}
+    State public state;
+    uint public x;
+    
+    constructor() {
+        state = State.A;
+        x = 0;
+    }
+
+    modifier inStates(State a, State b) {
+        require(state == a || state == b);
+        _;
+    }
+
+    //Should have two edges, A -> C and B -> C
+    function moveToC() public inStates(State.A, State.B) {
+        while (true) {
+            x++;
+        }
+
+        for (uint i = 0; i < 10; i++) {
+            x++;
+        }
+        state = State.C;
+    }
+}

--- a/corpus_studies/solidity_state_study/slither_plugins/tests/enums/RefundWallet.sol
+++ b/corpus_studies/solidity_state_study/slither_plugins/tests/enums/RefundWallet.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3
+pragma solidity ^0.8.4;
+
+contract RefundWallet {
+    enum State {Active, Success, Refunding, Closed}
+    State public state;
+
+    uint total;
+
+    modifier inState(State _state) {
+        require(state == _state);
+        _;
+    }
+
+    constructor() {
+        state = State.Active;
+        total = 0;
+    }
+
+    function deposit() external payable {
+        require(state == State.Active || state == State.Success);
+        total += msg.value;
+    }
+
+    function saleSuccessful() external inState(State.Active) {
+        state = State.Success;
+    }
+
+    function enableRefunds() external {
+        require(state != State.Refunding && state != State.Closed);
+        state = State.Refunding;
+    }
+
+    function refund() external inState(State.Refunding) {
+        total = 0;
+    }
+
+    function close() external inState(State.Success) {
+        state = State.Closed;
+    }
+
+    function doWhileClosed() external inState(State.Closed) {
+        
+    }
+}

--- a/corpus_studies/solidity_state_study/slither_plugins/tests/enums/Unreachable.sol
+++ b/corpus_studies/solidity_state_study/slither_plugins/tests/enums/Unreachable.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BSD-3
+pragma solidity ^0.8.4;
+
+contract Foo {
+    // Transition graph:
+    // A --> B <--> C
+    //
+    // D
+    // Initial state: B
+    // Unreachable states: A, D
+    enum State {A, B, C, D}
+    State public state;
+    uint public x;
+    
+    constructor() {
+        state = State.B;
+        x = 0;
+    }
+
+    modifier inState(State s) {
+        require(state == s);
+        _;
+    }
+
+    function goToB() public {
+        require(state == State.A || state == State.C);
+        state = State.B;
+    }
+
+    function goToC() public inState(State.B) {
+        state = State.C;
+    }
+}


### PR DESCRIPTION
Added a detector for contracts with boolean states to find "deactivation" patterns. Since this shared a lot of functionality with the previous enum detector, I moved a lot of the code from EnumGraphInferrer into a GraphInferrer parent class, from which BoolGraphInferrer and EnumGraphInferrer inherit from.
Also added additional files for testing.