### PR TITLE
generate flat yul object from child contracts

### DIFF
--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -37,6 +37,7 @@ object "{{creationObject}}" {
             if iszero(lt(calldatasize(), 4)) {
                 {{#dispatch}}
                     {{! TODO 224 is a magic number offset to shift to follow the spec above; check that it's right }}
+                    let this := 0 // todo
                     let selector := shr(224, calldataload(0))
                     {{dispatchCase}}
                 {{/dispatch}}

--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -37,7 +37,7 @@ object "{{creationObject}}" {
             if iszero(lt(calldatasize(), 4)) {
                 {{#dispatch}}
                     {{! TODO 224 is a magic number offset to shift to follow the spec above; check that it's right }}
-                    let this := 0 // todo
+                    let this := address()
                     let selector := shr(224, calldataload(0))
                     {{dispatchCase}}
                 {{/dispatch}}

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -140,7 +140,17 @@ object CodeGenYul extends CodeGenerator {
         mainContract
     }
 
-    // return statements that go to deploy object, and statements that go to runtime object
+
+    /**
+      * compute the translation of a declaration into yul with respect to its context in the larger
+      * obsidian program
+      *
+      * @param declaration  the declaration to translate
+      * @param contractName the name of the contract in which the declaration appears
+      * @param checkedTable the symbol table for the contract in which the declaration appears
+      * @param inMain       whether or not the contract in which the declaration apepars is the main one
+      * @return the yul statements corresponding to the declaration
+      */
     def translateDeclaration(declaration: Declaration, contractName: String, checkedTable: SymbolTable, inMain: Boolean): Seq[YulStatement] = {
         declaration match {
             case f: Field => translateField(f)

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -196,6 +196,7 @@ object CodeGenYul extends CodeGenerator {
     }
 
     def translateConstructor(constructor: Constructor, contractName: String, checkedTable: SymbolTable): Seq[YulStatement] = {
+        assert(false) // todo: this is never getting called as far as i know, and i don't really think it should be so i want to know about it if it is
         val new_name: String = "constructor_" + constructor.name
         val deployExpr = FunctionCall(
             Identifier(new_name), // TODO change how to find constructor function name after adding randomized suffix/prefix

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -474,7 +474,6 @@ object CodeGenYul extends CodeGenerator {
                 }
             case e: UnaryExpression =>
                 e match {
-                    // todo: this call to translateStatement is cute, but frankly the "inMain" argument does not particularly make sense here.
                     case LogicalNegation(e) => translateStatement(IfThenElse(e, Seq(FalseLiteral()), Seq(TrueLiteral())), Some(retvar.name), contractName, checkedTable, inMain)
                     case Negate(e) =>
                         translateExpr(retvar, Subtract(NumLiteral(0), e), contractName, checkedTable, inMain)

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -50,6 +50,7 @@ object CodeGenYul extends CodeGenerator {
             throw new RuntimeException("No main contract found")
         }
         val mainName = findMainContractName(ast)
+
         // prepare finalOutputPath
         val finalOutputPath = options.outputPath match {
             case Some(p) =>
@@ -57,12 +58,12 @@ object CodeGenYul extends CodeGenerator {
             case None =>
                 Paths.get(mainName)
         }
+        
         // translate from obsidian AST to yul AST
         val translated_obj = translateProgram(ast, checkedTable)
-        // generate yul string from yul AST
+
+        // generate yul string from yul AST, write to the output file
         val s = translated_obj.yulString()
-        // write string to output file
-        // currently it's created in the Obsidian directory; this may need to be changed, based on desired destination
         Files.createDirectories(finalOutputPath)
         val writer = new FileWriter(new File(finalOutputPath.toString, translated_obj.name + ".yul"))
         writer.write(s)
@@ -243,7 +244,7 @@ object CodeGenYul extends CodeGenerator {
             if (inMain) {
                 Seq() // add nothing
             } else {
-                Seq(TypedName("this","string")) // todo "this" is emphatically not a string but i'm not sure what the type of it ought to be; addr?
+                Seq(TypedName("this", "string")) // todo "this" is emphatically not a string but i'm not sure what the type of it ought to be; addr?
             } ++ transaction.args.map(v => TypedName(v.varName, obsTypeToYulTypeAndSize(v.typIn.toString)._1))
 
         // form the body of the transaction by translating each statement found
@@ -552,9 +553,9 @@ object CodeGenYul extends CodeGenerator {
 
                 ((decl_0exp(id_recipient) +: recipient_yul) ++
                     translateExpr(retvar, LocalInvocation(transactionNameMapping(getContractName(recipient), name),
-                                                genericParams,
-                                                params,
-                                                this_address +: args), contractName, checkedTable, inMain))
+                        genericParams,
+                        params,
+                        this_address +: args), contractName, checkedTable, inMain))
 
             case Construction(contractType, args, isFFIInvocation) =>
                 // todo: currently we ignore the arguments to the constructor

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -35,7 +35,7 @@ object CodeGenYul extends CodeGenerator {
     }
 
     // todo this is getting redundant, find a better way
-    def nextRet(): String = {
+    def nextRet(): String = { // todo: make this an indentifier not a string; that'll force a change to translateStatement
         retCnt = retCnt + 1
         s"_ret_${retCnt.toString}" //todo: better naming convention?
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -35,7 +35,7 @@ object CodeGenYul extends CodeGenerator {
     }
 
     // todo this is getting redundant, find a better way
-    def nextRet(): String = { // todo: make this an indentifier not a string; that'll force a change to translateStatement
+    def nextRet(): String = { // todo: make this an identifier not a string; that'll force a change to translateStatement
         retCnt = retCnt + 1
         s"_ret_${retCnt.toString}" //todo: better naming convention?
     }
@@ -547,6 +547,7 @@ object CodeGenYul extends CodeGenerator {
 
                 // todo: this does not work with non-void functions that are called without binding
                 //  their results, ie "f()" if f returns an int
+                ids.map(id => decl_0exp(id)) ++
                 seqs.flatten ++ (width match {
                     case 0 => Seq(ExpressionStatement(FunctionCall(Identifier(name), ids)))
                     case 1 =>
@@ -565,7 +566,7 @@ object CodeGenYul extends CodeGenerator {
                 //  can call the appropriate translated transaction in the big Yul object.
 
                 // we get a variable storing the address of the instance from recursively translating
-                // the recipient. we also form a Parser indentifier with this, so that we can translate
+                // the recipient. we also form a Parser identifier with this, so that we can translate
                 // the invocation with a tailcall to translateExpr
                 val id_recipient: Identifier = nextTemp()
                 val this_address = edu.cmu.cs.obsidian.parser.ReferenceIdentifier(id_recipient.name)

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -519,8 +519,12 @@ object CodeGenYul extends CodeGenerator {
                             0
                         } else if (name == transactionNameMapping("IntContainer", "get")) {
                             1
+                        } else if (name == transactionNameMapping("IntContainer", "set1")) {
+                            0
+                        } else if (name == transactionNameMapping("IntContainer", "set2")) {
+                            0
                         } else {
-                            assert(false)
+                            assert(false, s"width of transaction named ${name}")
                         }
                 }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -284,7 +284,6 @@ object CodeGenYul extends CodeGenerator {
       * @return
       */
     def translateStatement(s: Statement, retVar: Option[Identifier], contractName: String, checkedTable: SymbolTable, inMain: Boolean): Seq[YulStatement] = {
-        //todo: why is retVar an option?
         s match {
             case Return() =>
                 Seq(Leave())

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -129,10 +129,10 @@ object CodeGenYul extends CodeGenerator {
     }
 
 
-    def translateNonMainContract(c: ObsidianContractImpl, checkedTable: SymbolTable, mainContract : YulObject): YulObject = {
+    def translateNonMainContract(c: ObsidianContractImpl, checkedTable: SymbolTable, mainContract: YulObject): YulObject = {
         var statement_seq_runtime: Seq[YulStatement] = Seq()
 
-        for (d <- c.declarations){
+        for (d <- c.declarations) {
             val runtime_seq = translateDeclaration(d, c.name, checkedTable, false)
             statement_seq_runtime = statement_seq_runtime ++ runtime_seq
         }
@@ -144,10 +144,8 @@ object CodeGenYul extends CodeGenerator {
     def translateDeclaration(declaration: Declaration, contractName: String, checkedTable: SymbolTable, inMain: Boolean): Seq[YulStatement] = {
         declaration match {
             case f: Field => translateField(f)
-            case t: Transaction =>
-                translateTransaction(t, contractName, checkedTable)
-            case s: State =>
-               translateState(s)
+            case t: Transaction => translateTransaction(t, contractName, checkedTable)
+            case s: State => translateState(s)
             case c: ObsidianContractImpl =>
                 assert(assertion = false, "TODO")
                 Seq()
@@ -157,11 +155,11 @@ object CodeGenYul extends CodeGenerator {
             case _: Constructor =>
                 assert(assertion = false, "constructors not supported in Yul translation")
                 Seq()
-                // todo: previously this returned a pair of sequences, and this was the only clause
-                //   in which the left element was not empty. the left sequence would go in the code
-                //   part of the output object rather than the runtime, but that's not where we
-                //   want constructors to go.
-                // (translateConstructor(c, contractName, checkedTable), Seq())
+            // todo: previously this returned a pair of sequences, and this was the only clause
+            //   in which the left element was not empty. the left sequence would go in the code
+            //   part of the output object rather than the runtime, but that's not where we
+            //   want constructors to go.
+            // (translateConstructor(c, contractName, checkedTable), Seq())
             case _: TypeDecl =>
                 assert(assertion = false, "TODO")
                 Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -23,6 +23,10 @@ trait YulStatement extends YulAST
 // for each asm struct, create a case class
 case class TypedName(name: String, ntype: String) extends YulAST {
     override def toString: String = {
+        name
+/*
+ideally we'd want to do something like this:
+
         s"$name ${
             if (ntype.isEmpty) {
                 ""
@@ -30,6 +34,15 @@ case class TypedName(name: String, ntype: String) extends YulAST {
                 s" : $ntype"
             }
         }"
+
+but as of Sept2021, solc does not support that output even though it's in the def, e.g.
+
+Error: "string" is not a valid type (user defined types are not yet supported).
+   --> /sources/SetGetNoArgsNoConstructNoInit.yul:144:29:
+    |
+144 | function IntContainer___get(this  : string) -> _ret_2 {
+    |                             ^^^^^^^^^^^^^^
+*/
     }
 }
 


### PR DESCRIPTION
This make a flat Yul object with updated transactions from child contracts. Fields are still stored in storage, not memory, and I'm not sure about the treatment of this in the dispatch table.