### PR TITLE
memoize type info

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -10,19 +10,23 @@ trait HasLocation {
     var loc: Position = NoPosition
 
     def setLoc(t: Token): this.type = {
-        loc = t.pos; this
+        loc = t.pos;
+        this
     }
 
     def setLoc(other: HasLocation): this.type = {
-        loc = other.loc; this
+        loc = other.loc;
+        this
     }
 
     def setLoc(id: (String, Position)): this.type = {
-        loc = id._2; this
+        loc = id._2;
+        this
     }
 
     def setLoc(pos: Position): this.type = {
-        loc = pos; this
+        loc = pos;
+        this
     }
 }
 
@@ -36,7 +40,8 @@ sealed abstract class Statement() extends AST {
 /* All expressions are statements. We relegate the pruning of expressions
  * that don't have effects to a later analysis */
 sealed abstract class Expression() extends Statement {
-    val obstype : Option[ObsidianType]
+    val obstype: Option[ObsidianType]
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Expression
 }
 
@@ -85,12 +90,14 @@ sealed abstract class InvokableDeclaration() extends Declaration {
 // Expressions not containing other expressions
 sealed abstract class AtomicExpression extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): AtomicExpression = this
 }
 
 sealed abstract class UnaryExpression(make: Expression => UnaryExpression,
                                       e: Expression) extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): UnaryExpression =
         make(e.substitute(genericParams, actualParams)).setLoc(this)
 }
@@ -99,6 +106,7 @@ sealed abstract class BinaryExpression(make: (Expression, Expression) => BinaryE
                                        e1: Expression,
                                        e2: Expression) extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): BinaryExpression =
         make(e1.substitute(genericParams, actualParams), e2.substitute(genericParams, actualParams))
             .setLoc(this)
@@ -170,6 +178,7 @@ case class Dereference(e: Expression, f: String) extends UnaryExpression(Derefer
 case class LocalInvocation(name: String, genericParams: Seq[GenericType],
                            params: Seq[ObsidianType], args: Seq[Expression]) extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): LocalInvocation =
         LocalInvocation(name,
             genericParams,
@@ -183,6 +192,7 @@ case class LocalInvocation(name: String, genericParams: Seq[GenericType],
 case class Invocation(recipient: Expression, genericParams: Seq[GenericType], params: Seq[ObsidianType],
                       name: String, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def toString: String = s"$recipient.$name(${args.mkString(",")})"
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Invocation =
@@ -196,6 +206,7 @@ case class Invocation(recipient: Expression, genericParams: Seq[GenericType], pa
 
 case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Construction =
         Construction(contractType.substitute(genericParams, actualParams),
             args.map(_.substitute(genericParams, actualParams)), isFFIInvocation)
@@ -206,6 +217,7 @@ case class Disown(e: Expression) extends UnaryExpression(Disown, e)
 
 case class StateInitializer(stateName: Identifier, fieldName: Identifier) extends Expression {
     val obstype: Option[ObsidianType] = None
+
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): StateInitializer = this
 }
 
@@ -441,7 +453,7 @@ case class Ensures(expr: Expression) extends AST {
             .setLoc(this)
 }
 
-sealed abstract trait ContractModifier extends HasLocation
+sealed trait ContractModifier extends HasLocation
 
 case class IsAsset() extends ContractModifier
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -113,8 +113,8 @@ sealed abstract class BinaryExpression(make: (Expression, Expression) => BinaryE
 }
 
 /* Expressions */
-case class ReferenceIdentifier(name: String, typ: ObsidianType) extends AtomicExpression {
-    override val obstype: Option[ObsidianType] = Some(typ)
+case class ReferenceIdentifier(name: String, typ: Option[ObsidianType]) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = typ
 
     override val toString: String = name
 }
@@ -141,8 +141,8 @@ case class FalseLiteral() extends AtomicExpression {
     override def toString: String = "false"
 }
 
-case class This(typ: ObsidianType) extends AtomicExpression {
-    override val obstype: Option[ObsidianType] = Some(typ) // todo is this right? should this be a contractReferenceType?
+case class This(typ: Option[ObsidianType]) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = typ // todo is this right? should this be a contractReferenceType?
 
     override def toString: String = "this"
 }
@@ -223,8 +223,8 @@ case class Dereference(e: Expression, f: String) extends UnaryExpression(Derefer
 }
 
 case class LocalInvocation(name: String, genericParams: Seq[GenericType],
-                           params: Seq[ObsidianType], args: Seq[Expression], typ: ObsidianType) extends Expression {
-    override val obstype: Option[ObsidianType] = Some(typ)
+                           params: Seq[ObsidianType], args: Seq[Expression], typ: Option[ObsidianType]) extends Expression {
+    override val obstype: Option[ObsidianType] = typ
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): LocalInvocation =
         LocalInvocation(name,
@@ -237,8 +237,8 @@ case class LocalInvocation(name: String, genericParams: Seq[GenericType],
 }
 
 case class Invocation(recipient: Expression, genericParams: Seq[GenericType], params: Seq[ObsidianType],
-                      name: String, args: Seq[Expression], isFFIInvocation: Boolean, typ: ObsidianType) extends Expression {
-    override val obstype: Option[ObsidianType] = Some(typ)
+                      name: String, args: Seq[Expression], isFFIInvocation: Boolean, typ: Option[ObsidianType]) extends Expression {
+    override val obstype: Option[ObsidianType] = typ
 
     override def toString: String = s"$recipient.$name(${args.mkString(",")})"
 
@@ -251,8 +251,8 @@ case class Invocation(recipient: Expression, genericParams: Seq[GenericType], pa
             .setLoc(this)
 }
 
-case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean, typ: ObsidianType) extends Expression {
-    override val obstype: Option[ObsidianType] = Some(typ)
+case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean, typ: Option[ObsidianType]) extends Expression {
+    override val obstype: Option[ObsidianType] = typ
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Construction =
         Construction(contractType.substitute(genericParams, actualParams),
@@ -262,8 +262,8 @@ case class Construction(contractType: ContractType, args: Seq[Expression], isFFI
 
 case class Disown(e: Expression) extends UnaryExpression(Disown, e) // todo there's something happening that i don't understand
 
-case class StateInitializer(stateName: Identifier, fieldName: Identifier, typ: ObsidianType) extends Expression {
-    override val obstype: Option[ObsidianType] = Some(typ)
+case class StateInitializer(stateName: Identifier, fieldName: Identifier, typ: Option[ObsidianType]) extends Expression {
+    override val obstype: Option[ObsidianType] = typ
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): StateInitializer = this
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -215,7 +215,7 @@ case class NotEquals(e1: Expression, e2: Expression) extends BinaryExpression(No
 }
 
 case class Dereference(e: Expression, f: String) extends UnaryExpression(Dereference(_, f), e) {
-    override val obstype: Option[ObsidianType] = e.obstype // todo
+    override val obstype: Option[ObsidianType] = e.obstype
 
     override def toString: String = {
         s"$e.$f"

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -10,22 +10,22 @@ trait HasLocation {
     var loc: Position = NoPosition
 
     def setLoc(t: Token): this.type = {
-        loc = t.pos;
+        loc = t.pos
         this
     }
 
     def setLoc(other: HasLocation): this.type = {
-        loc = other.loc;
+        loc = other.loc
         this
     }
 
     def setLoc(id: (String, Position)): this.type = {
-        loc = id._2;
+        loc = id._2
         this
     }
 
     def setLoc(pos: Position): this.type = {
-        loc = pos;
+        loc = pos
         this
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -36,6 +36,7 @@ sealed abstract class Statement() extends AST {
 /* All expressions are statements. We relegate the pruning of expressions
  * that don't have effects to a later analysis */
 sealed abstract class Expression() extends Statement {
+    val obstype : Option[ObsidianType]
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Expression
 }
 
@@ -83,11 +84,13 @@ sealed abstract class InvokableDeclaration() extends Declaration {
 
 // Expressions not containing other expressions
 sealed abstract class AtomicExpression extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): AtomicExpression = this
 }
 
 sealed abstract class UnaryExpression(make: Expression => UnaryExpression,
                                       e: Expression) extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): UnaryExpression =
         make(e.substitute(genericParams, actualParams)).setLoc(this)
 }
@@ -95,6 +98,7 @@ sealed abstract class UnaryExpression(make: Expression => UnaryExpression,
 sealed abstract class BinaryExpression(make: (Expression, Expression) => BinaryExpression,
                                        e1: Expression,
                                        e2: Expression) extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): BinaryExpression =
         make(e1.substitute(genericParams, actualParams), e2.substitute(genericParams, actualParams))
             .setLoc(this)
@@ -165,6 +169,7 @@ case class Dereference(e: Expression, f: String) extends UnaryExpression(Derefer
 
 case class LocalInvocation(name: String, genericParams: Seq[GenericType],
                            params: Seq[ObsidianType], args: Seq[Expression]) extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): LocalInvocation =
         LocalInvocation(name,
             genericParams,
@@ -177,6 +182,7 @@ case class LocalInvocation(name: String, genericParams: Seq[GenericType],
 
 case class Invocation(recipient: Expression, genericParams: Seq[GenericType], params: Seq[ObsidianType],
                       name: String, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def toString: String = s"$recipient.$name(${args.mkString(",")})"
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Invocation =
@@ -189,6 +195,7 @@ case class Invocation(recipient: Expression, genericParams: Seq[GenericType], pa
 }
 
 case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Construction =
         Construction(contractType.substitute(genericParams, actualParams),
             args.map(_.substitute(genericParams, actualParams)), isFFIInvocation)
@@ -198,6 +205,7 @@ case class Construction(contractType: ContractType, args: Seq[Expression], isFFI
 case class Disown(e: Expression) extends UnaryExpression(Disown, e)
 
 case class StateInitializer(stateName: Identifier, fieldName: Identifier) extends Expression {
+    val obstype: Option[ObsidianType] = None
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): StateInitializer = this
 }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -141,8 +141,8 @@ case class FalseLiteral() extends AtomicExpression {
     override def toString: String = "false"
 }
 
-case class This(contractReferenceType: ContractReferenceType) extends AtomicExpression {
-    override val obstype: Option[ObsidianType] = Some(contractReferenceType) // todo is this right?
+case class This(typ: ObsidianType) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(typ) // todo is this right? should this be a contractReferenceType?
 
     override def toString: String = "this"
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -1,16 +1,29 @@
 package edu.cmu.cs.obsidian.parser
 
-import scala.util.parsing.input.{NoPosition, Position}
 import edu.cmu.cs.obsidian.lexer.Token
 import edu.cmu.cs.obsidian.parser.Parser.Identifier
 import edu.cmu.cs.obsidian.typecheck._
 
+import scala.util.parsing.input.{NoPosition, Position}
+
 trait HasLocation {
     var loc: Position = NoPosition
-    def setLoc(t: Token): this.type = { loc = t.pos; this }
-    def setLoc(other: HasLocation): this.type = { loc = other.loc; this }
-    def setLoc(id: (String, Position)): this.type = { loc = id._2; this }
-    def setLoc(pos: Position): this.type = { loc = pos; this }
+
+    def setLoc(t: Token): this.type = {
+        loc = t.pos; this
+    }
+
+    def setLoc(other: HasLocation): this.type = {
+        loc = other.loc; this
+    }
+
+    def setLoc(id: (String, Position)): this.type = {
+        loc = id._2; this
+    }
+
+    def setLoc(pos: Position): this.type = {
+        loc = pos; this
+    }
 }
 
 sealed abstract class AST() extends HasLocation
@@ -29,11 +42,17 @@ sealed abstract class Expression() extends Statement {
 /* this is to circumnavigate type erasure: it makes it possible to match on the exact
  * type of a Declarations at runtime */
 sealed trait DeclarationTag
+
 object TypeDeclTag extends DeclarationTag
+
 object FieldDeclTag extends DeclarationTag
+
 object ContractDeclTag extends DeclarationTag
+
 object StateDeclTag extends DeclarationTag
+
 object ConstructorDeclTag extends DeclarationTag
+
 object TransactionDeclTag extends DeclarationTag
 
 sealed abstract class Declaration() extends AST {
@@ -54,7 +73,7 @@ sealed abstract class InvokableDeclaration() extends Declaration {
     val initialFieldTypes: Map[String, ObsidianType] = Map.empty
     val finalFieldTypes: Map[String, ObsidianType] = Map.empty
 
-    def bodyEnd : AST =
+    def bodyEnd: AST =
         if (body.nonEmpty) {
             body.last
         } else {
@@ -89,33 +108,55 @@ case class ReferenceIdentifier(name: String) extends AtomicExpression {
 case class NumLiteral(value: Int) extends AtomicExpression {
     override def toString: String = value.toString
 }
+
 case class StringLiteral(value: String) extends AtomicExpression
-case class TrueLiteral() extends AtomicExpression{
+
+case class TrueLiteral() extends AtomicExpression {
     override def toString: String = "true"
 }
-case class FalseLiteral() extends AtomicExpression{
+
+case class FalseLiteral() extends AtomicExpression {
     override def toString: String = "false"
 }
+
 case class This() extends AtomicExpression {
     override def toString: String = "this"
 }
+
 case class Parent() extends AtomicExpression
+
 case class Conjunction(e1: Expression, e2: Expression) extends BinaryExpression(Conjunction, e1, e2)
+
 case class Disjunction(e1: Expression, e2: Expression) extends BinaryExpression(Disjunction, e1, e2)
+
 case class LogicalNegation(e: Expression) extends UnaryExpression(LogicalNegation, e)
+
 case class Add(e1: Expression, e2: Expression) extends BinaryExpression(Add, e1, e2)
+
 case class StringConcat(e1: Expression, e2: Expression) extends BinaryExpression(StringConcat, e1, e2)
+
 case class Subtract(e1: Expression, e2: Expression) extends BinaryExpression(Subtract, e1, e2)
+
 case class Divide(e1: Expression, e2: Expression) extends BinaryExpression(Divide, e1, e2)
+
 case class Multiply(e1: Expression, e2: Expression) extends BinaryExpression(Multiply, e1, e2)
+
 case class Mod(e1: Expression, e2: Expression) extends BinaryExpression(Mod, e1, e2)
+
 case class Negate(e: Expression) extends UnaryExpression(Negate, e)
+
 case class Equals(e1: Expression, e2: Expression) extends BinaryExpression(Equals, e1, e2)
+
 case class GreaterThan(e1: Expression, e2: Expression) extends BinaryExpression(GreaterThan, e1, e2)
+
 case class GreaterThanOrEquals(e1: Expression, e2: Expression) extends BinaryExpression(GreaterThanOrEquals, e1, e2)
+
 case class LessThan(e1: Expression, e2: Expression) extends BinaryExpression(LessThan, e1, e2)
+
 case class LessThanOrEquals(e1: Expression, e2: Expression) extends BinaryExpression(LessThanOrEquals, e1, e2)
+
 case class NotEquals(e1: Expression, e2: Expression) extends BinaryExpression(NotEquals, e1, e2)
+
 case class Dereference(e: Expression, f: String) extends UnaryExpression(Dereference(_, f), e) {
     override def toString: String = {
         s"$e.$f"
@@ -133,6 +174,7 @@ case class LocalInvocation(name: String, genericParams: Seq[GenericType],
 
     override def toString: String = s"$name(${args.mkString(",")})"
 }
+
 case class Invocation(recipient: Expression, genericParams: Seq[GenericType], params: Seq[ObsidianType],
                       name: String, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
     override def toString: String = s"$recipient.$name(${args.mkString(",")})"
@@ -145,13 +187,16 @@ case class Invocation(recipient: Expression, genericParams: Seq[GenericType], pa
             args.map(_.substitute(genericParams, actualParams)), isFFIInvocation)
             .setLoc(this)
 }
+
 case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Construction =
         Construction(contractType.substitute(genericParams, actualParams),
             args.map(_.substitute(genericParams, actualParams)), isFFIInvocation)
             .setLoc(this)
 }
+
 case class Disown(e: Expression) extends UnaryExpression(Disown, e)
+
 case class StateInitializer(stateName: Identifier, fieldName: Identifier) extends Expression {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): StateInitializer = this
 }
@@ -162,6 +207,7 @@ case class VariableDecl(typ: ObsidianType, varName: String) extends Statement {
         VariableDecl(typ.substitute(genericParams, actualParams), varName)
             .setLoc(this)
 }
+
 case class VariableDeclWithInit(typ: ObsidianType, varName: String, e: Expression) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): VariableDeclWithInit =
         VariableDeclWithInit(typ.substitute(genericParams, actualParams), varName,
@@ -174,12 +220,14 @@ case class VariableDeclWithSpec(typIn: ObsidianType, typOut: ObsidianType, varNa
         VariableDeclWithSpec(typIn.substitute(genericParams, actualParams),
             typOut.substitute(genericParams, actualParams), varName)
             .setLoc(this)
+
     override def toString: String = varName
 }
 
 case class Return() extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Return = this
 }
+
 case class ReturnExpr(e: Expression) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): ReturnExpr =
         ReturnExpr(e.substitute(genericParams, actualParams))
@@ -197,21 +245,25 @@ case class Transition(newStateName: String, updates: Option[Seq[(ReferenceIdenti
         Transition(newStateName, updates.map(_.map(doSubstitute)), thisPermission).setLoc(this)
     }
 }
+
 case class Assignment(assignTo: Expression, e: Expression) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Assignment =
         Assignment(assignTo.substitute(genericParams, actualParams), e.substitute(genericParams, actualParams))
             .setLoc(this)
 }
+
 case class Revert(maybeExpr: Option[Expression]) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Revert =
         Revert(maybeExpr.map(_.substitute(genericParams, actualParams)))
             .setLoc(this)
 }
+
 case class If(eCond: Expression, s: Seq[Statement]) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): If =
         If(eCond.substitute(genericParams, actualParams), s.map(_.substitute(genericParams, actualParams)))
             .setLoc(this)
 }
+
 case class IfThenElse(eCond: Expression, s1: Seq[Statement], s2: Seq[Statement]) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): IfThenElse =
         IfThenElse(eCond.substitute(genericParams, actualParams),
@@ -219,6 +271,7 @@ case class IfThenElse(eCond: Expression, s1: Seq[Statement], s2: Seq[Statement])
             s2.map(_.substitute(genericParams, actualParams)))
             .setLoc(this)
 }
+
 case class IfInState(e: Expression, ePerm: Permission, typeState: TypeState, s1: Seq[Statement], s2: Seq[Statement]) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Statement = {
         val newTypeState = typeState match {
@@ -233,11 +286,13 @@ case class IfInState(e: Expression, ePerm: Permission, typeState: TypeState, s1:
             s2.map(_.substitute(genericParams, actualParams))).setLoc(this)
     }
 }
+
 case class TryCatch(s1: Seq[Statement], s2: Seq[Statement]) extends Statement {
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): TryCatch =
         TryCatch(s1.map(_.substitute(genericParams, actualParams)), s2.map(_.substitute(genericParams, actualParams)))
             .setLoc(this)
 }
+
 // TODO GENERIC: We could just compile switches to an if-else tree to simplify things.
 //  However, that would require a default. Given we currently have no such thing, it's basically
 //  impossible to write a polymorphic switch
@@ -247,6 +302,7 @@ case class Switch(e: Expression, cases: Seq[SwitchCase]) extends Statement {
             cases.map(_.substitute(genericParams, actualParams)))
             .setLoc(this)
 }
+
 case class SwitchCase(stateName: String, body: Seq[Statement]) extends AST {
     def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): SwitchCase = {
         SwitchCase(stateName, body.map(_.substitute(genericParams, actualParams)))
@@ -358,8 +414,9 @@ case class Transaction(name: String,
         }
 }
 
-case class FSMEdge (fromState: Identifier, toState: Identifier) extends AST;
-case class Transitions(edges: Seq[FSMEdge]) extends AST;
+case class FSMEdge(fromState: Identifier, toState: Identifier) extends AST
+
+case class Transitions(edges: Seq[FSMEdge]) extends AST
 
 
 case class State(name: String, fields: Seq[Field], isAsset: Boolean) extends Declaration {
@@ -377,8 +434,11 @@ case class Ensures(expr: Expression) extends AST {
 }
 
 sealed abstract trait ContractModifier extends HasLocation
+
 case class IsAsset() extends ContractModifier
+
 case class IsMain() extends ContractModifier
+
 case class IsImport() extends ContractModifier
 
 case class Import(name: String) extends AST
@@ -388,21 +448,24 @@ sealed abstract class Contract(name: String, val sourcePath: String) extends Dec
     def params: Seq[GenericType]
 
     def declarations: Seq[Declaration]
+
     def modifiers: Set[ContractModifier] = Set.empty
-    val isAsset = modifiers.contains(IsAsset())
-    val isMain = modifiers.contains(IsMain())
-    val isImport = modifiers.contains(IsImport())
+
+    val isAsset: Boolean = modifiers.contains(IsAsset())
+    val isMain: Boolean = modifiers.contains(IsMain())
+    val isImport: Boolean = modifiers.contains(IsImport())
 
     def isInterface: Boolean
+
     def bound: ContractType
 }
 
 case class ObsidianContractImpl(override val modifiers: Set[ContractModifier],
-                    name: String, params: Seq[GenericType], bound: ContractType,
-                    override val declarations: Seq[Declaration],
-                    transitions: Option[Transitions],
-                    isInterface: Boolean,
-                    sp: String) extends Contract (name, sp) {
+                                name: String, params: Seq[GenericType], bound: ContractType,
+                                override val declarations: Seq[Declaration],
+                                transitions: Option[Transitions],
+                                isInterface: Boolean,
+                                sp: String) extends Contract(name, sp) {
     val tag: DeclarationTag = ContractDeclTag
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): ObsidianContractImpl =
@@ -418,11 +481,13 @@ case class JavaFFIContractImpl(name: String,
                                interface: String,
                                javaPath: Seq[Identifier],
                                sp: String,
-                               override val declarations: Seq[Declaration] = Seq.empty) extends Contract(name, sp){
+                               override val declarations: Seq[Declaration] = Seq.empty) extends Contract(name, sp) {
     val tag: DeclarationTag = ContractDeclTag
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): JavaFFIContractImpl = this
+
     override def bound: ContractType = ContractType(interface, Nil)
+
     override def isInterface: Boolean = false
 
     override def params: Seq[GenericType] = Nil

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/AST.scala
@@ -113,85 +113,132 @@ sealed abstract class BinaryExpression(make: (Expression, Expression) => BinaryE
 }
 
 /* Expressions */
-case class ReferenceIdentifier(name: String) extends AtomicExpression {
+case class ReferenceIdentifier(name: String, typ: ObsidianType) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(typ)
+
     override val toString: String = name
 }
 
 case class NumLiteral(value: Int) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+
     override def toString: String = value.toString
 }
 
-case class StringLiteral(value: String) extends AtomicExpression
+case class StringLiteral(value: String) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(StringType())
+}
 
 case class TrueLiteral() extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+
     override def toString: String = "true"
 }
 
 case class FalseLiteral() extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+
     override def toString: String = "false"
 }
 
-case class This() extends AtomicExpression {
+case class This(contractReferenceType: ContractReferenceType) extends AtomicExpression {
+    override val obstype: Option[ObsidianType] = Some(contractReferenceType) // todo is this right?
+
     override def toString: String = "this"
 }
 
-case class Parent() extends AtomicExpression
+case class Parent() extends AtomicExpression //todo type of parent?
 
-case class Conjunction(e1: Expression, e2: Expression) extends BinaryExpression(Conjunction, e1, e2)
+case class Conjunction(e1: Expression, e2: Expression) extends BinaryExpression(Conjunction, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class Disjunction(e1: Expression, e2: Expression) extends BinaryExpression(Disjunction, e1, e2)
+case class Disjunction(e1: Expression, e2: Expression) extends BinaryExpression(Disjunction, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class LogicalNegation(e: Expression) extends UnaryExpression(LogicalNegation, e)
+case class LogicalNegation(e: Expression) extends UnaryExpression(LogicalNegation, e) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class Add(e1: Expression, e2: Expression) extends BinaryExpression(Add, e1, e2)
 
-case class StringConcat(e1: Expression, e2: Expression) extends BinaryExpression(StringConcat, e1, e2)
+case class Add(e1: Expression, e2: Expression) extends BinaryExpression(Add, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+}
 
-case class Subtract(e1: Expression, e2: Expression) extends BinaryExpression(Subtract, e1, e2)
+case class StringConcat(e1: Expression, e2: Expression) extends BinaryExpression(StringConcat, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(StringType())
+}
 
-case class Divide(e1: Expression, e2: Expression) extends BinaryExpression(Divide, e1, e2)
+case class Subtract(e1: Expression, e2: Expression) extends BinaryExpression(Subtract, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+}
 
-case class Multiply(e1: Expression, e2: Expression) extends BinaryExpression(Multiply, e1, e2)
+case class Divide(e1: Expression, e2: Expression) extends BinaryExpression(Divide, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+}
 
-case class Mod(e1: Expression, e2: Expression) extends BinaryExpression(Mod, e1, e2)
+case class Multiply(e1: Expression, e2: Expression) extends BinaryExpression(Multiply, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+}
 
-case class Negate(e: Expression) extends UnaryExpression(Negate, e)
+case class Mod(e1: Expression, e2: Expression) extends BinaryExpression(Mod, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+}
 
-case class Equals(e1: Expression, e2: Expression) extends BinaryExpression(Equals, e1, e2)
+case class Negate(e: Expression) extends UnaryExpression(Negate, e) {
+    override val obstype: Option[ObsidianType] = Some(IntType())
+}
 
-case class GreaterThan(e1: Expression, e2: Expression) extends BinaryExpression(GreaterThan, e1, e2)
+case class Equals(e1: Expression, e2: Expression) extends BinaryExpression(Equals, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class GreaterThanOrEquals(e1: Expression, e2: Expression) extends BinaryExpression(GreaterThanOrEquals, e1, e2)
+case class GreaterThan(e1: Expression, e2: Expression) extends BinaryExpression(GreaterThan, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class LessThan(e1: Expression, e2: Expression) extends BinaryExpression(LessThan, e1, e2)
+case class GreaterThanOrEquals(e1: Expression, e2: Expression) extends BinaryExpression(GreaterThanOrEquals, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class LessThanOrEquals(e1: Expression, e2: Expression) extends BinaryExpression(LessThanOrEquals, e1, e2)
+case class LessThan(e1: Expression, e2: Expression) extends BinaryExpression(LessThan, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
-case class NotEquals(e1: Expression, e2: Expression) extends BinaryExpression(NotEquals, e1, e2)
+case class LessThanOrEquals(e1: Expression, e2: Expression) extends BinaryExpression(LessThanOrEquals, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
+
+case class NotEquals(e1: Expression, e2: Expression) extends BinaryExpression(NotEquals, e1, e2) {
+    override val obstype: Option[ObsidianType] = Some(BoolType())
+}
 
 case class Dereference(e: Expression, f: String) extends UnaryExpression(Dereference(_, f), e) {
+    override val obstype: Option[ObsidianType] = e.obstype // todo
+
     override def toString: String = {
         s"$e.$f"
     }
 }
 
 case class LocalInvocation(name: String, genericParams: Seq[GenericType],
-                           params: Seq[ObsidianType], args: Seq[Expression]) extends Expression {
-    val obstype: Option[ObsidianType] = None
+                           params: Seq[ObsidianType], args: Seq[Expression], typ: ObsidianType) extends Expression {
+    override val obstype: Option[ObsidianType] = Some(typ)
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): LocalInvocation =
         LocalInvocation(name,
             genericParams,
             params.map(_.substitute(genericParams, actualParams)),
-            args.map(_.substitute(genericParams, actualParams)))
+            args.map(_.substitute(genericParams, actualParams)), typ)
             .setLoc(this)
 
     override def toString: String = s"$name(${args.mkString(",")})"
 }
 
 case class Invocation(recipient: Expression, genericParams: Seq[GenericType], params: Seq[ObsidianType],
-                      name: String, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
-    val obstype: Option[ObsidianType] = None
+                      name: String, args: Seq[Expression], isFFIInvocation: Boolean, typ: ObsidianType) extends Expression {
+    override val obstype: Option[ObsidianType] = Some(typ)
 
     override def toString: String = s"$recipient.$name(${args.mkString(",")})"
 
@@ -200,23 +247,23 @@ case class Invocation(recipient: Expression, genericParams: Seq[GenericType], pa
             genericParams,
             params.map(_.substitute(genericParams, actualParams)),
             name,
-            args.map(_.substitute(genericParams, actualParams)), isFFIInvocation)
+            args.map(_.substitute(genericParams, actualParams)), isFFIInvocation, typ)
             .setLoc(this)
 }
 
-case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean) extends Expression {
-    val obstype: Option[ObsidianType] = None
+case class Construction(contractType: ContractType, args: Seq[Expression], isFFIInvocation: Boolean, typ: ObsidianType) extends Expression {
+    override val obstype: Option[ObsidianType] = Some(typ)
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): Construction =
         Construction(contractType.substitute(genericParams, actualParams),
-            args.map(_.substitute(genericParams, actualParams)), isFFIInvocation)
+            args.map(_.substitute(genericParams, actualParams)), isFFIInvocation, typ)
             .setLoc(this)
 }
 
-case class Disown(e: Expression) extends UnaryExpression(Disown, e)
+case class Disown(e: Expression) extends UnaryExpression(Disown, e) // todo there's something happening that i don't understand
 
-case class StateInitializer(stateName: Identifier, fieldName: Identifier) extends Expression {
-    val obstype: Option[ObsidianType] = None
+case class StateInitializer(stateName: Identifier, fieldName: Identifier, typ: ObsidianType) extends Expression {
+    override val obstype: Option[ObsidianType] = Some(typ)
 
     override def substitute(genericParams: Seq[GenericType], actualParams: Seq[ObsidianType]): StateInitializer = this
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -212,7 +212,7 @@ object Parser extends Parsers {
 
         val parseUpdate = {
             val oneUpdate = parseId ~! EqT() ~! parseExpr ^^ {
-                case f ~ _ ~ e => (ReferenceIdentifier(f._1).setLoc(f), e)
+                case f ~ _ ~ e => (ReferenceIdentifier(f._1, None).setLoc(f), e)
             }
             LParenT() ~ repsep(oneUpdate, CommaT()) ~ RParenT() ^^ {
                 case _ ~ updates ~ _ => updates
@@ -378,7 +378,7 @@ object Parser extends Parsers {
         def parseLocalInv = {
             parseId ~ parseTypeList ~ LParenT() ~ parseArgList ~ RParenT() ^^ {
                 // genericParams will be filled in later by the typechecker
-                case name ~ params ~ _ ~ args ~ _ => LocalInvocation(name._1, Nil, params, args).setLoc(name)
+                case name ~ params ~ _ ~ args ~ _ => LocalInvocation(name._1, Nil, params, args, None).setLoc(name)
             }
         }
 
@@ -390,7 +390,7 @@ object Parser extends Parsers {
                 (e: Expression, inv: DotExpr) => inv match {
                     case Left(fieldName) => Dereference(e, fieldName._1).setLoc(fieldName)
                     // genericParams will be filled in later by the typechecker
-                    case Right((funcName, params, args)) => Invocation(e, Nil, params, funcName._1, args, false).setLoc(funcName)
+                    case Right((funcName, params, args)) => Invocation(e, Nil, params, funcName._1, args, false, None).setLoc(funcName)
                 }
             )
         }
@@ -409,10 +409,10 @@ object Parser extends Parsers {
             case _ ~ e ~ _ => e
         }
 
-        val parseVar = parseId ^^ { (id: Identifier) => ReferenceIdentifier(id._1).setLoc(id) }
+        val parseVar = parseId ^^ { (id: Identifier) => ReferenceIdentifier(id._1, None).setLoc(id) }
 
         val parseStateInitializer = parseId ~ ColonColonT() ~! parseId ^^ {
-            case stateName ~ _ ~ fieldName => StateInitializer(stateName, fieldName).setLoc(stateName)
+            case stateName ~ _ ~ fieldName => StateInitializer(stateName, fieldName, None).setLoc(stateName)
         }
 
         val parseNumLiteral = {
@@ -427,7 +427,7 @@ object Parser extends Parsers {
                         case None => Nil
                     }
 
-                    Construction(ContractType(name._1, typeParams), args, false).setLoc(_new)
+                    Construction(ContractType(name._1, typeParams), args, false, None).setLoc(_new)
             }
         }
 
@@ -437,7 +437,7 @@ object Parser extends Parsers {
         val parseLiterals: Parser[Expression] =
             parseTrue | parseFalse | parseNumLiteral | parseStringLiteral
 
-        val parseThis = { ThisT() ^^ (t => This().setLoc(t))}
+        val parseThis = { ThisT() ^^ (t => This(None).setLoc(t))}
 
         val fail = failure("expression expected")
 

--- a/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/parser/Parser.scala
@@ -1,12 +1,10 @@
 package edu.cmu.cs.obsidian.parser
 
-import java.io.{InputStream, StringWriter}
-
-import edu.cmu.cs.obsidian.{lexer, parser}
 import edu.cmu.cs.obsidian.lexer._
 import edu.cmu.cs.obsidian.typecheck._
 import org.apache.commons.io.IOUtils
 
+import java.io.{InputStream, StringWriter}
 import scala.util.parsing.combinator._
 import scala.util.parsing.input.Position
 
@@ -44,7 +42,8 @@ object Parser extends Parsers {
     private def parseId: Parser[Identifier] = {
         accept("identifier", {
             case t@IdentifierT(name) => (name, t.pos)
-            case t@ThisT() => ("this", t.pos)})
+            case t@ThisT() => ("this", t.pos)
+        })
     }
 
     private def parseIdAlternatives: Parser[Seq[Identifier]] = {
@@ -72,7 +71,6 @@ object Parser extends Parsers {
     }
 
 
-
     private def parseDotPath: Parser[Seq[Identifier]] = DotT() ~ parseId ~ opt(parseDotPath) ^^ {
         case _ ~ ident ~ rest => {
             rest match {
@@ -82,13 +80,13 @@ object Parser extends Parsers {
         }
     }
 
-    private def parsePath: Parser[Seq[Identifier]] = parseId ~ opt(parseDotPath) ^^{
-      case ident ~ rest => {
-        rest match {
-          case Some(path) => List(ident) ++ path
-          case None => List(ident)
+    private def parsePath: Parser[Seq[Identifier]] = parseId ~ opt(parseDotPath) ^^ {
+        case ident ~ rest => {
+            rest match {
+                case Some(path) => List(ident) ++ path
+                case None => List(ident)
+            }
         }
-      }
     }
 
     private def parseNonPrimitive: Parser[NonPrimitiveType] = {
@@ -114,7 +112,7 @@ object Parser extends Parsers {
         val intPrim = IntT() ^^ { t => IntType().setLoc(t) }
         val boolPrim = BoolT() ^^ { t => BoolType().setLoc(t) }
         val stringPrim = StringT() ^^ { t => StringType().setLoc(t) }
-        val int256Prim = Int256T() ^^ {t => Int256Type().setLoc(t)}
+        val int256Prim = Int256T() ^^ { t => Int256Type().setLoc(t) }
 
         parseNonPrimitive | intPrim | boolPrim | stringPrim | int256Prim
     }
@@ -154,6 +152,7 @@ object Parser extends Parsers {
                     case (typIn, typOut) ~ name => VariableDeclWithSpec(typIn, typOut, name._1).setLoc(name)
                 }
             }
+
             def isDefinedAt(x: (ObsidianType, ObsidianType) ~ Identifier): Boolean = {
                 x match {
                     case ((typIn, typOut) ~ name) =>
@@ -220,7 +219,7 @@ object Parser extends Parsers {
         }
 
         val parseTransition = RightArrowT() ~ parseId ~
-                              opt(parseUpdate) ~! SemicolonT() ^^ {
+            opt(parseUpdate) ~! SemicolonT() ^^ {
             case arrow ~ name ~ updates ~ _ => Transition(name._1, updates, Inferred()).setLoc(arrow)
         }
 
@@ -228,7 +227,7 @@ object Parser extends Parsers {
             parseType ~ parseId ~ EqT() ~! parseExpr ~! SemicolonT() ^^ {
                 case typ ~ name ~ _ ~ e ~ _ =>
                     VariableDeclWithInit(typ, name._1, e).setLoc(typ)
-        }
+            }
 
         val parseVarDecl =
             parseType ~ parseId ~! SemicolonT() ^^ {
@@ -243,7 +242,6 @@ object Parser extends Parsers {
         val parseRevert = RevertT() ~! opt(parseExpr) ~! SemicolonT() ^^ {
             case t ~ expr ~ _ => Revert(expr).setLoc(t)
         }
-
 
 
         val parseOnlyIf = IfT() ~! opt(LParenT()) ~ parseExpr ~! opt(InT() ~! parseId) ~ opt(RParenT()) ~! LBraceT() ~! parseBody ~! RBraceT()
@@ -265,7 +263,7 @@ object Parser extends Parsers {
         }
 
         val parseTryCatch = TryT() ~! LBraceT() ~! parseBody ~! RBraceT() ~!
-                            CatchT() ~! LBraceT() ~! parseBody <~ RBraceT() ^^ {
+            CatchT() ~! LBraceT() ~! parseBody <~ RBraceT() ^^ {
             case _try ~ _ ~ s1 ~ _ ~ _ ~ _ ~ s2 => TryCatch(s1, s2).setLoc(_try)
         }
 
@@ -276,7 +274,7 @@ object Parser extends Parsers {
         val parseSwitch =
             SwitchT() ~! parseExpr ~! LBraceT() ~! rep(parseCase) ~! RBraceT() ^^ {
                 case switch ~ e ~ _ ~ cases ~ _ => Switch(e, cases).setLoc(switch)
-        }
+            }
 
         val parseTypeState = parseIdAlternatives ^^ {
             idents =>
@@ -307,8 +305,8 @@ object Parser extends Parsers {
         }
 
         parseReturn | parseTransition | parseRevert |
-        parseVarDeclAssn | parseVarDecl | parseIf | parseSwitch |
-        parseTryCatch | parseExprFirst | parseStaticAssertion
+            parseVarDeclAssn | parseVarDecl | parseIf | parseSwitch |
+            parseTryCatch | parseExprFirst | parseStaticAssertion
     }
 
 
@@ -328,9 +326,9 @@ object Parser extends Parsers {
     }
 
     private def parseUnary(t: Token,
-                   makeExpr: Expression => Expression,
-                   nextParser: Parser[Expression]
-                  ): Parser[Expression] = {
+                           makeExpr: Expression => Expression,
+                           nextParser: Parser[Expression]
+                          ): Parser[Expression] = {
         val hasOpParser = t ~ parseUnary(t, makeExpr, nextParser) ^^ {
             case op ~ e => makeExpr(e).setLoc(op)
         }
@@ -339,24 +337,38 @@ object Parser extends Parsers {
     }
 
     private def parseExpr = parseDisown
+
     private def parseDisown = parseUnary(DisownT(), Disown
         .apply, parseAnd)
+
     private def parseAnd = parseBinary(AndT(), Conjunction.apply, parseOr)
+
     private def parseOr = parseBinary(OrT(), Disjunction.apply, parseEq)
 
     private def parseEq = parseBinary(EqEqT(), Equals.apply, parseNeq)
+
     private def parseNeq = parseBinary(NotEqT(), NotEquals.apply, parseGt)
+
     private def parseGt = parseBinary(GtT(), GreaterThan.apply, parseLt)
+
     private def parseLt = parseBinary(LtT(), LessThan.apply, parseLtEq)
+
     private def parseLtEq = parseBinary(LtEqT(), LessThanOrEquals.apply, parseGtEq)
+
     private def parseGtEq = parseBinary(GtEqT(), GreaterThanOrEquals.apply, parseAddition)
 
     private def parseAddition = parseBinary(PlusT(), Add.apply, parseSubtraction)
+
     private def parseSubtraction = parseBinary(MinusT(), Subtract.apply, parseMultiplication)
+
     private def parseMultiplication = parseBinary(StarT(), Multiply.apply, parseDivision)
+
     private def parseDivision = parseBinary(ForwardSlashT(), Divide.apply, parseMod)
+
     private def parseMod = parseBinary(PercentT(), Mod.apply, parseNot)
+
     private def parseNot = parseUnary(NotT(), LogicalNegation.apply, parseUnaryMinus)
+
     private def parseUnaryMinus = parseUnary(MinusT(), Negate.apply, parseExprBottom)
 
 
@@ -431,27 +443,33 @@ object Parser extends Parsers {
             }
         }
 
-        val parseTrue = { accept("bool literal", { case t@TrueT() => TrueLiteral().setLoc(t) })}
-        val parseFalse = { accept("bool literal", { case t@FalseT() => FalseLiteral().setLoc(t) })}
+        val parseTrue = {
+            accept("bool literal", { case t@TrueT() => TrueLiteral().setLoc(t) })
+        }
+        val parseFalse = {
+            accept("bool literal", { case t@FalseT() => FalseLiteral().setLoc(t) })
+        }
 
         val parseLiterals: Parser[Expression] =
             parseTrue | parseFalse | parseNumLiteral | parseStringLiteral
 
-        val parseThis = { ThisT() ^^ (t => This(None).setLoc(t))}
+        val parseThis = {
+            ThisT() ^^ (t => This(None).setLoc(t))
+        }
 
         val fail = failure("expression expected")
 
         val simpleExpr: Parser[Expression] =
             parseThis | parseNew | parseLocalInv |
-            parseLiterals | parseStateInitializer | parseVar | parenExpr | fail
+                parseLiterals | parseStateInitializer | parseVar | parenExpr | fail
 
         simpleExpr ~ parseDots ^^ { case e ~ applyDots => applyDots(e) }
     }
 
     private def parseFieldDecl: Parser[Field] = {
         opt(ConstT()) ~ parseType ~ parseId ~! opt(parseAvailableIn) ~!
-                opt(EqT() ~! parseExpr ~! failure("fields may only be assigned inside of transactions")) ~!
-                SemicolonT() ^^ {
+            opt(EqT() ~! parseExpr ~! failure("fields may only be assigned inside of transactions")) ~!
+            SemicolonT() ^^ {
             case isConst ~ typ ~ name ~ availableIn ~ None ~ _ =>
                 val availableInSet = availableIn match {
                     case Some(idents) => Some(idents.map(_._1))
@@ -462,7 +480,7 @@ object Parser extends Parsers {
                         Field(isConst = true, typ, name._1, availableInSet).setLoc(constToken)
                     case None =>
                         Field(isConst = false, typ, name._1, availableInSet).setLoc(typ)
-            }
+                }
             //TODO: replace this RuntimeException with a more appropriate error, maybe a call to failure()
             case _ ~ _ ~ _ ~ _ ~ Some(x) ~ _ => throw new RuntimeException("available in fields only permitted at the top level of contracts")
         }
@@ -474,8 +492,8 @@ object Parser extends Parsers {
 
     private def parseStatesList: Parser[Set[Identifier]] =
         rep(parseId ~ CommaT()) ~! parseId ^^ {
-        case ors ~ last => ors.map(_._1).toSet + last
-    }
+            case ors ~ last => ors.map(_._1).toSet + last
+        }
 
     private def parseEnsures = {
         EnsuresT() ~! parseExpr ~! SemicolonT() ^^ {
@@ -489,8 +507,8 @@ object Parser extends Parsers {
         }
     }
 
-    private def parseTransBody(isInterface:Boolean) =  {
-        if(isInterface) SemicolonT() ^^ {
+    private def parseTransBody(isInterface: Boolean) = {
+        if (isInterface) SemicolonT() ^^ {
             case _ => Seq.empty[Statement]
         }
         else LBraceT() ~! parseBody ~! RBraceT() ^^ {
@@ -498,7 +516,7 @@ object Parser extends Parsers {
         }
     }
 
-    case class TransactionOptions (isStatic: Boolean, isPrivate: Boolean)
+    case class TransactionOptions(isStatic: Boolean, isPrivate: Boolean)
 
     private def parseTransactionOptions: Parser[TransactionOptions] = {
         rep(StaticT() | PrivateT()) ^^ {
@@ -531,10 +549,10 @@ object Parser extends Parsers {
     }
 
 
-    private def parseTransDecl(params: List[GenericType], isInterface:Boolean)(contractName: String, contractParams: Seq[GenericType]): Parser[Transaction] = {
+    private def parseTransDecl(params: List[GenericType], isInterface: Boolean)(contractName: String, contractParams: Seq[GenericType]): Parser[Transaction] = {
         parseTransactionOptions ~ opt(LParenT() ~! parseArgDefList(contractName) ~! RParenT()) ~ TransactionT() ~! (parseId | MainT()) ~!
             opt(LBracketT() ~ repsep(genericParam, CommaT()) ~ RBracketT()) ~! LParenT() ~! parseArgDefList(contractName) ~! RParenT() ~!
-            opt(parseReturns) ~! rep(parseEnsures) ~!  parseTransBody(isInterface) ^^ {
+            opt(parseReturns) ~! rep(parseEnsures) ~! parseTransBody(isInterface) ^^ {
             case opts ~ privateMethodFieldTypes ~ t ~ name ~ paramsOpt ~ _ ~ args ~ _ ~ returns ~ ensures ~ body =>
                 val nameString = name match {
                     case MainT() => "main"
@@ -559,11 +577,11 @@ object Parser extends Parsers {
                 def makeRemoteNonPrimitiveTypeTopLevelIfNeeded(np: NonPrimitiveType): NonPrimitiveType =
                     name match {
                         case MainT() =>
-                                if (np.isRemote) {
-                                    np.remoteType(TopLevelRemoteReferenceType())
-                                } else {
-                                    np
-                                }
+                            if (np.isRemote) {
+                                np.remoteType(TopLevelRemoteReferenceType())
+                            } else {
+                                np
+                            }
                         case _ => np
                     }
 
@@ -572,9 +590,9 @@ object Parser extends Parsers {
                         case MainT() => t match {
                             case np: NonPrimitiveType => makeRemoteNonPrimitiveTypeTopLevelIfNeeded(np)
                             case _ => t
-                            }
-                        case _ => t
                         }
+                        case _ => t
+                    }
 
                 val thisContractType = ContractType(contractName, contractParams)
 
@@ -598,7 +616,7 @@ object Parser extends Parsers {
                     case Some(_ ~ argDefList ~ _) => argDefList.map((v: VariableDeclWithSpec) => (v.varName, makeRemoteTypeTopLevelIfNeeded(v.typOut)))
                 }
 
-                val argTypesUpdatedWithRemoteTypes = filteredArgs.map( (d: VariableDeclWithSpec) =>
+                val argTypesUpdatedWithRemoteTypes = filteredArgs.map((d: VariableDeclWithSpec) =>
                     d match {
                         case VariableDeclWithSpec(typIn, typOut, varName) =>
                             VariableDeclWithSpec(makeRemoteTypeTopLevelIfNeeded(typIn), makeRemoteTypeTopLevelIfNeeded(typOut), varName).setLoc(d)
@@ -617,13 +635,13 @@ object Parser extends Parsers {
             case isAsset ~ st ~ name ~ maybeDefs ~ _ =>
                 maybeDefs match {
                     case None => State(name._1, Seq.empty, isAsset.isDefined).setLoc(st)
-                    case Some (_ ~ defs ~ _)  => State(name._1, defs, isAsset.isDefined).setLoc(st)
+                    case Some(_ ~ defs ~ _) => State(name._1, defs, isAsset.isDefined).setLoc(st)
                 }
         }
     }
 
     // TODO: maybe we can check here that the constructor has the appropriate name?
-    private def parseConstructor (params: Seq[GenericType]) = {
+    private def parseConstructor(params: Seq[GenericType]) = {
         parseId ~ opt(AtT() ~! parseIdAlternatives) ~! LParenT() ~! parseArgDefList("") ~! RParenT() ~! LBraceT() ~! parseBody ~! RBraceT() ^^ {
             case name ~ permission ~ _ ~ args ~ _ ~ _ ~ body ~ _ =>
                 val resultType = extractTypeFromPermission(permission, name._1, params, NotRemoteReferenceType(), defaultOwned = false)
@@ -631,8 +649,8 @@ object Parser extends Parsers {
         }
     }
 
-    private def parseDeclInContract(params: List[GenericType], isInterface:Boolean,
-                                    sourcePath: String)(contractName: String, contractParams: List[GenericType]):  Parser[Declaration] = {
+    private def parseDeclInContract(params: List[GenericType], isInterface: Boolean,
+                                    sourcePath: String)(contractName: String, contractParams: List[GenericType]): Parser[Declaration] = {
         parseFieldDecl | parseStateDecl | parseConstructor(contractParams) | parseContractDecl(sourcePath) |
             parseTransDecl(params, isInterface)(contractName, contractParams)
     }
@@ -712,7 +730,7 @@ object Parser extends Parsers {
         parseId ~! opt(LBracketT() ~ repsep(genericParam, CommaT()) ~ RBracketT()) ^^ {
             case id ~ optParams =>
                 optParams match {
-                    case Some(_ ~ params ~ _) =>  (id, params)
+                    case Some(_ ~ params ~ _) => (id, params)
                     case None => (id, List())
                 }
         }
@@ -731,32 +749,32 @@ object Parser extends Parsers {
                 }
 
                 LBraceT() ~! rep(parseTransitions | parseDeclInContract(params, isInterface, srcPath)(name._1, params)) ~! RBraceT() ^^ {
-                case _ ~ contents ~ _ =>
-                    // Make sure there's only one transition diagram.
-                    val separateTransitions = contents.filter({
-                        case t: Transitions => true
-                        case _ => false
-                    }).map(_.asInstanceOf[Transitions])
+                    case _ ~ contents ~ _ =>
+                        // Make sure there's only one transition diagram.
+                        val separateTransitions = contents.filter({
+                            case t: Transitions => true
+                            case _ => false
+                        }).map(_.asInstanceOf[Transitions])
 
-                    // For now, combine all the state transitions from all the different
-                    // transitions blocks.
-                    // Maybe eventually require that there is only one transitions block.
-                    val transitionsEdges = separateTransitions.foldLeft(List.empty[FSMEdge])((edges, t) => edges ++ t.edges)
+                        // For now, combine all the state transitions from all the different
+                        // transitions blocks.
+                        // Maybe eventually require that there is only one transitions block.
+                        val transitionsEdges = separateTransitions.foldLeft(List.empty[FSMEdge])((edges, t) => edges ++ t.edges)
 
-                    val transitions =
-                        if (transitionsEdges.isEmpty) {
-                            None
-                        } else {
-                            Some(Transitions(transitionsEdges))
-                        }
+                        val transitions =
+                            if (transitionsEdges.isEmpty) {
+                                None
+                            } else {
+                                Some(Transitions(transitionsEdges))
+                            }
 
-                    val decls = contents.filter({
-                        case d: Declaration => true
-                        case _ => false
-                    }).map(_.asInstanceOf[Declaration])
+                        val decls = contents.filter({
+                            case d: Declaration => true
+                            case _ => false
+                        }).map(_.asInstanceOf[Declaration])
 
-                    ObsidianContractImpl(mod.toSet, name._1, params, implementBound, decls, transitions, isInterface, srcPath).setLoc(ct)
-            }
+                        ObsidianContractImpl(mod.toSet, name._1, params, implementBound, decls, transitions, isInterface, srcPath).setLoc(ct)
+                }
         }
     }
 
@@ -786,7 +804,7 @@ object Parser extends Parsers {
         parseProgram(srcPath)(reader) match {
             case Success(result, _) => Right(result)
             case Failure(msg, reader) => Left(s"Parser failure at ${reader.pos}: $msg")
-            case Error(msg , next) =>
+            case Error(msg, next) =>
                 if (next.atEnd) {
                     Left(s"Parser Error: $msg at end of file")
                 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -679,9 +679,6 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         def updateType(e: Expression, typ: ObsidianType): Expression = {
             e match {
                 case expression: AtomicExpression => expression match {
-                    // per https://docs.scala-lang.org/tour/case-classes.html i think this:
-                    //      e.copy(obstype = Some(typ))
-                    // should work in all these cases, but it does not! fascinating.
                     case ReferenceIdentifier(name) => assert(false); e
                     case NumLiteral(value) => assert(false); e
                     case StringLiteral(value) => assert(false); e

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -676,7 +676,30 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             (resultType, contextAfterPrivateInvocation, isFFIInvocation, receiverPrime, foundTransaction.get.params, exprSequence)
         }
 
-         e match {
+        def updateType(e: Expression, typ: ObsidianType): Expression = {
+            e match {
+                case expression: AtomicExpression => expression match {
+                    // per https://docs.scala-lang.org/tour/case-classes.html i think this:
+                    //      e.copy(obstype = Some(typ))
+                    // should work in all these cases, but it does not! fascinating.
+                    case ReferenceIdentifier(name) => assert(false); e
+                    case NumLiteral(value) => assert(false); e
+                    case StringLiteral(value) => assert(false); e
+                    case TrueLiteral() => assert(false); e
+                    case FalseLiteral() => assert(false); e
+                    case This() => assert(false); e
+                    case Parent() => assert(false); e
+                } 
+                case expression: UnaryExpression => assert(false); e
+                case expression: BinaryExpression => assert(false); e
+                case LocalInvocation(name, genericParams, params, args) => assert(false); e
+                case Invocation(recipient, genericParams, params, name, args, isFFIInvocation) => assert(false); e
+                case Construction(contractType, args, isFFIInvocation) => assert(false); e
+                case StateInitializer(stateName, fieldName) => assert(false); e
+            }
+        }
+
+        val (retType, retCtx, retExp) = e match {
              case ReferenceIdentifier(x) =>
                  (context get x, context.lookupCurrentFieldTypeInThis(x)) match {
                      case (Some(t), _) =>
@@ -974,8 +997,11 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                          }
                  }
 
+                 //assert(! e.obstype.isEmpty, s"infer and check failed to populate the type of ${e.toString}")
                  (fieldType, context, e)
          }
+
+        (retType, retCtx, updateType(retExp,retType))
     }
 
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1,11 +1,9 @@
 package edu.cmu.cs.obsidian.typecheck
 
-import edu.cmu.cs.obsidian.parser.Parser.Identifier
 import edu.cmu.cs.obsidian.parser._
 
 import scala.collection.immutable.TreeMap
 import scala.collection.mutable
-import scala.collection.mutable.HashSet
 
 
 /* We define a custom type to store a special flag for if a context in after a "throw".
@@ -24,7 +22,7 @@ case class Context(table: DeclarationTable,
                    transitionFieldsMaybeInitialized: Set[(String, String, AST)], // stateName, fieldName, AST
                    localFieldsInitialized: Set[String],
                    thisFieldTypes: Map[String, ObsidianType],
-                   valVariables : Set[String]) {
+                   valVariables: Set[String]) {
     def keys: Iterable[String] = underlyingVariableMap.keys
 
     def updated(s: String, t: ObsidianType): Context =
@@ -36,6 +34,7 @@ case class Context(table: DeclarationTable,
             localFieldsInitialized,
             thisFieldTypes,
             valVariables)
+
     def updatedWithTransitionInitialization(stateName: String, fieldName: String, ast: AST): Context =
         Context(contractTable,
             underlyingVariableMap,
@@ -232,7 +231,7 @@ case class Context(table: DeclarationTable,
 }
 
 class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
-    private def consumptionModeForType(typ: ObsidianType) : OwnershipConsumptionMode = {
+    private def consumptionModeForType(typ: ObsidianType): OwnershipConsumptionMode = {
         typ match {
             case np: NonPrimitiveType =>
                 if (np.permission == Shared()) {
@@ -310,11 +309,11 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
                     interfaceMatches && argChecks
                 } else {
-                   obs1 == obs2 && c1.typeArgs.zip(c2.typeArgs).forall(checkArgCompat(table))
+                    obs1 == obs2 && c1.typeArgs.zip(c2.typeArgs).forall(checkArgCompat(table))
                 }
             case (jvcon1: JavaFFIContractImpl, jvcon2: JavaFFIContractImpl) => jvcon1 == jvcon2
             case (obs: ObsidianContractImpl, jvcon: JavaFFIContractImpl) => false
-            case (jvcon: JavaFFIContractImpl, obs:ObsidianContractImpl) => obs.name == jvcon.interface
+            case (jvcon: JavaFFIContractImpl, obs: ObsidianContractImpl) => obs.name == jvcon.interface
         })
     }
 
@@ -393,9 +392,9 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
     //-------------------------------------------------------------------------
     private def nonPrimitiveMergeTypes(
-            t1: NonPrimitiveType,
-            t2: NonPrimitiveType,
-            contractTable: ContractTable): Option[NonPrimitiveType] = {
+                                          t1: NonPrimitiveType,
+                                          t2: NonPrimitiveType,
+                                          contractTable: ContractTable): Option[NonPrimitiveType] = {
         if (t1.contractName != t2.contractName) return None
 
         (t1, t2) match {
@@ -544,7 +543,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         logError(ast, GenericParameterPermissionMissingError(param, param.gVar.permissionVar.get, nonPrimitiveActualArg))
                     }
                 case _ =>
-                    // Nothing to do here.
+                // Nothing to do here.
             }
         }
     }
@@ -577,11 +576,11 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         }
 
         def handleInvocation(
-                context: Context,
-                name: String,
-                receiver: Expression,
-                params: Seq[ObsidianType],
-                args: Seq[Expression]): (ObsidianType, Context, Boolean, Expression, Seq[GenericType], Seq[Expression]) = {
+                                context: Context,
+                                name: String,
+                                receiver: Expression,
+                                params: Seq[ObsidianType],
+                                args: Seq[Expression]): (ObsidianType, Context, Boolean, Expression, Seq[GenericType], Seq[Expression]) = {
             val (receiverType, contextAfterReceiver, receiverPrime) = inferAndCheckExpr(decl, context, receiver, NoOwnershipConsumption())
 
             // Terrible special case just for now. TODO: remove this.
@@ -602,13 +601,13 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             //Finding out if the Contract is a FFIContract
             val isFFIInvocation = receiverType match {
                 case BottomType() | UnitType() | IntType() | Int256Type() | BoolType() | StringType() => false
-                case np : NonPrimitiveType =>
+                case np: NonPrimitiveType =>
                     val contractTableOpt = context.contractTable.lookupContract(np.contractName)
                     contractTableOpt match {
                         case None => false
                         case Some(x) => x.contract match {
-                            case obsContract : ObsidianContractImpl => false
-                            case javaContract : JavaFFIContractImpl => true
+                            case obsContract: ObsidianContractImpl => false
+                            case javaContract: JavaFFIContractImpl => true
                         }
                     }
             }
@@ -616,7 +615,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
             val foundTransaction =
                 contextAfterReceiver.lookupTransactionInType(receiverType)(name)
-                .map(t => t.substitute(t.params, params))
+                    .map(t => t.substitute(t.params, params))
 
             val invokable: InvokableDeclaration = foundTransaction match {
                 case None =>
@@ -640,17 +639,17 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             for ((fieldName, requiredInitialFieldType) <- foundTransaction.get.initialFieldTypes) {
                 val currentFieldType = context.lookupCurrentFieldTypeInThis(fieldName)
                 currentFieldType match {
-                   case None => ()
-                   case Some(cft) => if(isSubtype(context.contractTable, cft, requiredInitialFieldType, receiver.isInstanceOf[This]).isDefined ||
-                                        (cft.isOwned != requiredInitialFieldType.isOwned && !cft.isBottom)) {
-                       logError(e, FieldSubtypingError(fieldName, cft, requiredInitialFieldType))
-                   }
+                    case None => ()
+                    case Some(cft) => if (isSubtype(context.contractTable, cft, requiredInitialFieldType, receiver.isInstanceOf[This]).isDefined ||
+                        (cft.isOwned != requiredInitialFieldType.isOwned && !cft.isBottom)) {
+                        logError(e, FieldSubtypingError(fieldName, cft, requiredInitialFieldType))
+                    }
                 }
             }
 
             // check arguments
             val spec = invokable.args
-            val specList = (spec, invokable)::Nil
+            val specList = (spec, invokable) :: Nil
 
             val (exprSequence, contextAfterArgs, correctInvokable) =
                 checkArgs(e, contextAfterReceiver, specList, args) match {
@@ -676,336 +675,316 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             (resultType, contextAfterPrivateInvocation, isFFIInvocation, receiverPrime, foundTransaction.get.params, exprSequence)
         }
 
-        def updateType(e: Expression, typ: ObsidianType): Expression = {
-            e match {
-                case expression: AtomicExpression => expression match {
-                    case ReferenceIdentifier(name) => assert(false); e
-                    case NumLiteral(value) => assert(false); e
-                    case StringLiteral(value) => assert(false); e
-                    case TrueLiteral() => assert(false); e
-                    case FalseLiteral() => assert(false); e
-                    case This() => assert(false); e
-                    case Parent() => assert(false); e
-                } 
-                case expression: UnaryExpression => assert(false); e
-                case expression: BinaryExpression => assert(false); e
-                case LocalInvocation(name, genericParams, params, args) => assert(false); e
-                case Invocation(recipient, genericParams, params, name, args, isFFIInvocation) => assert(false); e
-                case Construction(contractType, args, isFFIInvocation) => assert(false); e
-                case StateInitializer(stateName, fieldName) => assert(false); e
-            }
-        }
+        e match {
+            case ReferenceIdentifier(x, typ) =>
+                (context get x, context.lookupCurrentFieldTypeInThis(x)) match {
+                    case (Some(t), _) =>
+                        // We always want x to have the type according to the context, but sometimes we're going to consume ownership.
 
-        val (retType, retCtx, retExp) = e match {
-             case ReferenceIdentifier(x) =>
-                 (context get x, context.lookupCurrentFieldTypeInThis(x)) match {
-                     case (Some(t), _) =>
-                         // We always want x to have the type according to the context, but sometimes we're going to consume ownership.
+                        // Consuming in a context that expects ownership results in Unowned.
+                        // But consuming in a context that expects sharing results in Shared.
+                        val newType = t.residualType(ownershipConsumptionMode)
+                        if (newType != t) {
+                            (t, context.updated(x, newType), e)
+                        }
+                        else {
+                            (t, context, e)
+                        }
+                    case (_, Some(t)) =>
+                        val newType = t.residualType(ownershipConsumptionMode)
+                        if (newType != t) {
+                            (t, context.updatedThisFieldType(x, newType), e)
+                        }
+                        else {
+                            (t, context, e)
+                        }
+                    case (None, None) =>
+                        val tableLookup = context.contractTable.lookupContract(x)
+                        if (tableLookup.isDefined) {
+                            val contractTable = tableLookup.get
+                            val nonPrimitiveType = ContractReferenceType(contractTable.contractType, Shared(), NotRemoteReferenceType())
+                            (InterfaceContractType(contractTable.name, nonPrimitiveType), context, e)
+                        }
+                        else {
+                            logError(e, VariableUndefinedError(x, context.thisType.toString))
+                            (BottomType(), context, e)
+                        }
+                }
 
-                         // Consuming in a context that expects ownership results in Unowned.
-                         // But consuming in a context that expects sharing results in Shared.
-                         val newType = t.residualType(ownershipConsumptionMode)
-                         if (newType != t) {
-                             (t, context.updated(x, newType), e)
-                         }
-                         else {
-                             (t, context, e)
-                         }
-                     case (_, Some(t)) =>
-                         val newType = t.residualType(ownershipConsumptionMode)
-                         if (newType != t) {
-                             (t, context.updatedThisFieldType(x, newType), e)
-                         }
-                         else {
-                             (t, context, e)
-                         }
-                     case (None, None) =>
-                         val tableLookup = context.contractTable.lookupContract(x)
-                         if (tableLookup.isDefined) {
-                             val contractTable = tableLookup.get
-                             val nonPrimitiveType = ContractReferenceType(contractTable.contractType, Shared(), NotRemoteReferenceType())
-                             (InterfaceContractType(contractTable.name, nonPrimitiveType), context, e)
-                         }
-                         else {
-                             logError(e, VariableUndefinedError(x, context.thisType.toString))
-                             (BottomType(), context, e)
-                         }
-                 }
+            case NumLiteral(_) => (Int256Type(), context, e)
+            case StringLiteral(_) => (StringType(), context, e)
+            case TrueLiteral() => (BoolType(), context, e)
+            case FalseLiteral() => (BoolType(), context, e)
+            case This(typ) =>
+                val thisType = context.thisType
+                val newContext =
+                    if (ownershipConsumptionMode != NoOwnershipConsumption()) {
+                        context.updated("this", thisType.residualType(ownershipConsumptionMode))
+                    }
+                    else {
+                        context
+                    }
+                (thisType, newContext, e)
+            case Parent() =>
+                assert(false, "TODO: re-add support for parents")
+                /*
+                val thisTable = context.tableOfThis.contractTable
+                if (thisTable.hasParent) {
+                    val parentTable = thisTable.parent.get
+                    val ts = parentTable.simpleType
+                    val tr = if (parentTable.hasParent) {
+                        PathType("this"::"parent"::"parent"::Nil, ts)
+                    } else {
+                        ts
+                    }
 
-             case NumLiteral(_) => (Int256Type(), context, e)
-             case StringLiteral(_) => (StringType(), context, e)
-             case TrueLiteral() => (BoolType(), context, e)
-             case FalseLiteral() => (BoolType(), context, e)
-             case This() =>
-                 val thisType = context.thisType
-                 val newContext =
-                     if (ownershipConsumptionMode != NoOwnershipConsumption()) {
-                         context.updated("this", thisType.residualType(ownershipConsumptionMode))
-                     }
-                     else {
-                         context
-                     }
-                 (thisType, newContext, e)
-             case Parent() =>
-                 assert(false, "TODO: re-add support for parents")
-                 /*
-                 val thisTable = context.tableOfThis.contractTable
-                 if (thisTable.hasParent) {
-                     val parentTable = thisTable.parent.get
-                     val ts = parentTable.simpleType
-                     val tr = if (parentTable.hasParent) {
-                         PathType("this"::"parent"::"parent"::Nil, ts)
-                     } else {
-                         ts
-                     }
+                    (addModifiers(tr, parentTable, Set()), context)
 
-                     (addModifiers(tr, parentTable, Set()), context)
+                } else {
+                    logError(e, NoParentError(thisTable.name))
+                    (BottomType(), context)
+                }
+                */
+                (BottomType(), context, e)
+            case Conjunction(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, BoolType())
+                (typ, con, Conjunction(e1Prime, e2Prime).setLoc(e))
+            case Disjunction(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, BoolType())
+                (typ, con, Disjunction(e1Prime, e2Prime).setLoc(e))
+            case LogicalNegation(e: Expression) =>
+                val (typ, con, ePrime) = assertTypeEquality(e, BoolType(), context)
+                (typ, con, LogicalNegation(ePrime).setLoc(e))
 
-                 } else {
-                     logError(e, NoParentError(thisTable.name))
-                     (BottomType(), context)
-                 }
-                 */
-                 (BottomType(), context, e)
-             case Conjunction(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, BoolType())
-                 (typ, con, Conjunction(e1Prime, e2Prime).setLoc(e))
-             case Disjunction(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, BoolType())
-                 (typ, con, Disjunction(e1Prime, e2Prime).setLoc(e))
-             case LogicalNegation(e: Expression) =>
-                 val (typ, con, ePrime) = assertTypeEquality(e, BoolType(), context)
-                 (typ, con, LogicalNegation(ePrime).setLoc(e))
+            case Add(e1: Expression, e2: Expression) =>
+                val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
+                val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())
 
-             case Add(e1: Expression, e2: Expression) =>
-                 val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
-                 val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())
+                (t1, t2) match {
+                    // Propagate BottomType up if we can't infer a type for + here
+                    case (_: BottomType, _: BottomType) =>
+                        (BottomType(), c2, Add(e1Prime, e2Prime).setLoc(e))
+                    // Regular BigInt addition
+                    case (_: IntType | _: BottomType, _: IntType | _: BottomType) =>
+                        (IntType(), c2, Add(e1Prime, e2Prime).setLoc(e))
+                    // Int256 addition
+                    case (_: Int256Type | _: BottomType, _: Int256Type | _: BottomType) =>
+                        (Int256Type(), c2, Add(e1Prime, e2Prime).setLoc(e))
+                    // Int256 + Int
+                    case (_: Int256Type | _: BottomType, _: IntType | _: BottomType) =>
+                        (IntType(), c2, Add(e1Prime, e2Prime).setLoc(e))
+                    case (_: IntType | _: BottomType, _: Int256Type | _: BottomType) =>
+                        (IntType(), c2, Add(e1Prime, e2Prime).setLoc(e))
+                    // String concatenation
+                    case (_: StringType | _: BottomType, _: StringType | _: BottomType) =>
+                        (StringType(), c2, StringConcat(e1Prime, e2Prime).setLoc(e))
+                    case _ => {
+                        logError(e, PlusTypeError(t1, t2))
+                        (BottomType(), c2, Add(e1Prime, e2Prime).setLoc(e))
+                    }
+                }
 
-                 (t1, t2) match {
-                     // Propagate BottomType up if we can't infer a type for + here
-                     case (_: BottomType, _: BottomType) =>
-                         (BottomType(), c2, Add(e1Prime, e2Prime).setLoc(e))
-                     // Regular BigInt addition
-                     case (_: IntType | _: BottomType, _: IntType | _: BottomType) =>
-                         (IntType(), c2, Add(e1Prime, e2Prime).setLoc(e))
-                     // Int256 addition
-                     case (_: Int256Type | _: BottomType, _: Int256Type | _: BottomType) =>
-                         (Int256Type(), c2, Add(e1Prime, e2Prime).setLoc(e))
-                     // Int256 + Int
-                     case (_: Int256Type | _: BottomType, _: IntType | _: BottomType) =>
-                         (IntType(), c2, Add(e1Prime, e2Prime).setLoc(e))
-                     case (_: IntType | _: BottomType, _: Int256Type | _: BottomType) =>
-                         (IntType(), c2, Add(e1Prime, e2Prime).setLoc(e))
-                     // String concatenation
-                     case (_: StringType | _: BottomType, _: StringType | _: BottomType) =>
-                         (StringType(), c2, StringConcat(e1Prime, e2Prime).setLoc(e))
-                     case _ => {
-                         logError(e, PlusTypeError(t1, t2))
-                         (BottomType(), c2, Add(e1Prime, e2Prime).setLoc(e))
-                     }
-                 }
+            // Impossible - Values of this type are only ever produced by the typechecker
+            case StringConcat(_, _) => throw new RuntimeException("Impossible case")
 
-             // Impossible - Values of this type are only ever produced by the typechecker
-             case StringConcat(_, _) => throw new RuntimeException("Impossible case")
+            case Subtract(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
+                (typ, con, Subtract(e1Prime, e2Prime).setLoc(e))
+            case Divide(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
+                (typ, con, Divide(e1Prime, e2Prime).setLoc(e))
+            case Multiply(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
+                (typ, con, Multiply(e1Prime, e2Prime).setLoc(e))
+            case Mod(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
+                (typ, con, Mod(e1Prime, e2Prime).setLoc(e))
+            case Negate(e: Expression) =>
+                assertTypeEquality(e, IntType(), context)
+            case Equals(e1: Expression, e2: Expression) =>
+                val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
+                val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())
+                if ((t1 == t2) || (t1 == Int256Type() && t2 == IntType()) || (t1 == IntType() && t2 == Int256Type())) {
+                    (BoolType(), c2, Equals(e1Prime, e2Prime).setLoc(e))
+                } else {
+                    if (!t1.isBottom && !t2.isBottom) {
+                        logError(e, DifferentTypeError(e1, t1, e2, t2))
+                    }
+                    (BottomType(), c2, Equals(e1Prime, e2Prime).setLoc(e))
+                }
+            case GreaterThan(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
+                (typ, con, GreaterThan(e1Prime, e2Prime).setLoc(e))
+            case GreaterThanOrEquals(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
+                (typ, con, GreaterThanOrEquals(e1Prime, e2Prime).setLoc(e))
+            case LessThan(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
+                (typ, con, LessThan(e1Prime, e2Prime).setLoc(e))
+            case LessThanOrEquals(e1: Expression, e2: Expression) =>
+                val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
+                (typ, con, LessThanOrEquals(e1Prime, e2Prime).setLoc(e))
+            case NotEquals(e1: Expression, e2: Expression) =>
+                val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
+                val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())
+                if ((t1 == t2) || (t1 == Int256Type() && t2 == IntType()) || (t1 == IntType() && t2 == Int256Type())) {
+                    (BoolType(), c2, NotEquals(e1Prime, e2Prime).setLoc(e))
+                } else {
+                    if (!t1.isBottom && !t2.isBottom) {
+                        logError(e, DifferentTypeError(e1, t1, e2, t2))
+                    }
+                    (BottomType(), c2, NotEquals(e1Prime, e2Prime).setLoc(e))
+                }
 
-             case Subtract(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
-                 (typ, con, Subtract(e1Prime, e2Prime).setLoc(e))
-             case Divide(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
-                 (typ, con, Divide(e1Prime, e2Prime).setLoc(e))
-             case Multiply(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
-                 (typ, con, Multiply(e1Prime, e2Prime).setLoc(e))
-             case Mod(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
-                 (typ, con, Mod(e1Prime, e2Prime).setLoc(e))
-             case Negate(e: Expression) =>
-                 assertTypeEquality(e, IntType(), context)
-             case Equals(e1: Expression, e2: Expression) =>
-                 val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
-                 val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())
-                 if ((t1 == t2) || (t1 == Int256Type() && t2 == IntType()) || (t1 == IntType() && t2 == Int256Type())) {
-                     (BoolType(), c2, Equals(e1Prime, e2Prime).setLoc(e))
-                 } else {
-                     if (!t1.isBottom && !t2.isBottom) {
-                         logError(e, DifferentTypeError(e1, t1, e2, t2))
-                     }
-                     (BottomType(), c2, Equals(e1Prime, e2Prime).setLoc(e))
-                 }
-             case GreaterThan(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
-                 (typ, con, GreaterThan(e1Prime, e2Prime).setLoc(e))
-             case GreaterThanOrEquals(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
-                 (typ, con, GreaterThanOrEquals(e1Prime, e2Prime).setLoc(e))
-             case LessThan(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
-                 (typ, con, LessThan(e1Prime, e2Prime).setLoc(e))
-             case LessThanOrEquals(e1: Expression, e2: Expression) =>
-                 val (typ, con, e1Prime, e2Prime) = assertComparisonType(e1, e2)
-                 (typ, con, LessThanOrEquals(e1Prime, e2Prime).setLoc(e))
-             case NotEquals(e1: Expression, e2: Expression) =>
-                 val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
-                 val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())
-                 if ((t1 == t2) || (t1 == Int256Type() && t2 == IntType()) || (t1 == IntType() && t2 == Int256Type())) {
-                     (BoolType(), c2, NotEquals(e1Prime, e2Prime).setLoc(e))
-                 } else {
-                     if (!t1.isBottom && !t2.isBottom) {
-                         logError(e, DifferentTypeError(e1, t1, e2, t2))
-                     }
-                     (BottomType(), c2, NotEquals(e1Prime, e2Prime).setLoc(e))
-                 }
+            case Dereference(eDeref: Expression, fieldName) =>
+                eDeref match {
+                    case This(typ) =>
+                        context.lookupCurrentFieldTypeInThis(fieldName) match {
+                            case Some(t) =>
+                                val newType = t.residualType(ownershipConsumptionMode)
+                                if (newType != t) {
+                                    (t, context.updatedThisFieldType(fieldName, newType), e)
+                                }
+                                else {
+                                    (t, context, e)
+                                }
+                            case None =>
+                                logError(e, FieldUndefinedError(context.thisType, fieldName))
+                                (BottomType(), context, e)
+                        }
 
-             case Dereference(eDeref: Expression, fieldName) =>
-                 eDeref match {
-                     case This() =>
-                         context.lookupCurrentFieldTypeInThis(fieldName) match {
-                             case Some(t) =>
-                                 val newType = t.residualType(ownershipConsumptionMode)
-                                 if (newType != t) {
-                                     (t, context.updatedThisFieldType(fieldName, newType), e)
-                                 }
-                                 else {
-                                     (t, context, e)
-                                 }
-                             case None =>
-                                 logError(e, FieldUndefinedError(context.thisType, fieldName))
-                                 (BottomType(), context, e)
-                         }
+                    case _ =>
+                        val (newExpr: Expression, newContext: Context) =
+                            inferAndCheckExpr(decl, context, eDeref, ownershipConsumptionMode) match {
+                                case (np: NonPrimitiveType, c, ePrime) =>
+                                    logError(e, InvalidNonThisFieldAccess())
+                                    (ePrime, c)
+                                case (typ, c, ePrime) =>
+                                    if (!typ.isBottom) {
+                                        logError(e, DereferenceError(typ))
+                                    }
+                                    (ePrime, c)
+                            }
+                        (BottomType(), newContext, newExpr)
+                }
 
-                     case _ =>
-                         val (newExpr: Expression, newContext: Context) =
-                             inferAndCheckExpr(decl, context, eDeref, ownershipConsumptionMode) match {
-                                 case (np: NonPrimitiveType, c, ePrime) =>
-                                     logError(e, InvalidNonThisFieldAccess())
-                                     (ePrime, c)
-                                 case (typ, c, ePrime) =>
-                                     if (!typ.isBottom) {
-                                         logError(e, DereferenceError(typ))
-                                     }
-                                     (ePrime, c)
-                             }
-                         (BottomType(), newContext, newExpr)
-                 }
+            case LocalInvocation(name, _, params, args: Seq[Expression], obstype) =>
+                //todo should there be an assertion to check that obstype == typ? which one takes precedence?
+                //todo i don't konw if passing `obstype` to This is correct at all
+                val (typ, con, _, _, newGenericParams, newArgs) = handleInvocation(context, name, This(obstype).setLoc(e), params, args)
+                //This may need correction.
+                (typ, con, LocalInvocation(name, newGenericParams, params, newArgs, typ).setLoc(e))
 
-             case LocalInvocation(name, _, params, args: Seq[Expression]) =>
-                 val (typ, con, _, _, newGenericParams, newArgs) = handleInvocation(context, name, This().setLoc(e), params, args)
-                 //This may need correction.
-                 (typ, con, LocalInvocation(name, newGenericParams, params, newArgs).setLoc(e))
+            case Invocation(receiver: Expression, _, params, name, args: Seq[Expression], isFFIInvocation, obstype) =>
+                //todo should there be an assertion to check that obstype == typ? which one takes precedence?
+                val (typ, con, isFFIInv, newReceiver, newGenericParams, newArgs) = handleInvocation(context, name, receiver, params, args)
+                (typ, con, Invocation(newReceiver, newGenericParams, params, name, newArgs, isFFIInv, typ).setLoc(e))
 
-             case Invocation(receiver: Expression, _, params, name, args: Seq[Expression], isFFIInvocation) =>
-                 val (typ, con, isFFIInv, newReceiver, newGenericParams, newArgs) = handleInvocation(context, name, receiver, params, args)
-                 (typ, con, Invocation(newReceiver, newGenericParams, params, name, newArgs, isFFIInv).setLoc(e))
+            case c@Construction(contractType, args: Seq[Expression], isFFIInvocation, obstyp) =>
+                val tableLookup = context.contractTable.lookupContract(contractType.contractName)
+                val isFFIInv = tableLookup match {
+                    case None => false
+                    case Some(x) => x.contract match {
+                        case obsContract: ObsidianContractImpl => false
+                        case javaContract: JavaFFIContractImpl => true
+                    }
+                }
 
-             case c@Construction(contractType, args: Seq[Expression], isFFIInvocation) =>
-                 val tableLookup = context.contractTable.lookupContract(contractType.contractName)
-                 val isFFIInv = tableLookup match {
-                     case None => false
-                     case Some(x) => x.contract match {
-                         case obsContract: ObsidianContractImpl => false
-                         case javaContract: JavaFFIContractImpl => true
-                     }
-                 }
+                if (tableLookup.isEmpty) {
+                    logError(e, ContractUndefinedError(contractType.contractName))
+                    return (BottomType(), context, e)
+                }
 
-                 if (tableLookup.isEmpty) {
-                     logError(e, ContractUndefinedError(contractType.contractName))
-                     return (BottomType(), context, e)
-                 }
-
-                 if (tableLookup.get.contract.isInterface) {
+                if (tableLookup.get.contract.isInterface) {
                     logError(e, InterfaceInstantiationError(contractType.contractName))
-                 }
+                }
 
-                 tableLookup.get.contract match {
-                     case obsCon: ObsidianContractImpl =>
-                         substituteOk(tableLookup.get, c, obsCon.params, contractType.typeArgs)
-                     case javaCon: JavaFFIContractImpl => ()
-                 }
+                tableLookup.get.contract match {
+                    case obsCon: ObsidianContractImpl =>
+                        substituteOk(tableLookup.get, c, obsCon.params, contractType.typeArgs)
+                    case javaCon: JavaFFIContractImpl => ()
+                }
 
-                 val ctTableOfConstructed = tableLookup.get.substitute(contractType.typeArgs)
+                val ctTableOfConstructed = tableLookup.get.substitute(contractType.typeArgs)
 
-                 val constrSpecs = ctTableOfConstructed
-                                    .constructors
-                                    .map(constr => (constr.args, constr))
+                val constrSpecs = ctTableOfConstructed
+                    .constructors
+                    .map(constr => (constr.args, constr))
 
-                 val result = checkArgs(e, context, constrSpecs.to(collection.immutable.Seq), args)
+                val result = checkArgs(e, context, constrSpecs.to(collection.immutable.Seq), args)
 
-                 val (exprList, simpleType, contextPrime) = result match {
-                     // Even if the args didn't check, we can still output a type
-                     case None => (Nil, ContractReferenceType(contractType, Owned(), NotRemoteReferenceType()), context)
-                     case Some((newExprSequence, cntxt, constr)) =>
-                         val outTyp = constr.asInstanceOf[Constructor].resultType match {
-                             case ContractReferenceType(_, permission, isRemote) =>
-                                 ContractReferenceType(contractType, permission, isRemote)
-                             case StateType(_, stateNames, isRemote) =>
-                                 StateType(contractType, stateNames, isRemote)
-                             case t => t
-                         }
-                         (newExprSequence, outTyp, cntxt)
-                 }
+                val (exprList, simpleType, contextPrime) = result match {
+                    // Even if the args didn't check, we can still output a type
+                    case None => (Nil, ContractReferenceType(contractType, Owned(), NotRemoteReferenceType()), context)
+                    case Some((newExprSequence, cntxt, constr)) =>
+                        val outTyp = constr.asInstanceOf[Constructor].resultType match {
+                            case ContractReferenceType(_, permission, isRemote) =>
+                                ContractReferenceType(contractType, permission, isRemote)
+                            case StateType(_, stateNames, isRemote) =>
+                                StateType(contractType, stateNames, isRemote)
+                            case t => t
+                        }
+                        (newExprSequence, outTyp, cntxt)
+                }
 
-                 (simpleType, contextPrime, Construction(contractType, exprList, isFFIInv))
+                (simpleType, contextPrime, Construction(contractType, exprList, isFFIInv, simpleType))
 
-             case Disown(e) =>
-                 // The expression "disown e" evaluates to an unowned value but also side-effects the context
-                 // so that e is no longer owned (if it is a variable).
-                 val (typ, contextPrime, ePrime) = inferAndCheckExpr(decl, context, e, ownershipConsumptionMode)
-                 if (!typ.isOwned) {
+            case Disown(e) =>
+                // The expression "disown e" evaluates to an unowned value but also side-effects the context
+                // so that e is no longer owned (if it is a variable).
+                val (typ, contextPrime, ePrime) = inferAndCheckExpr(decl, context, e, ownershipConsumptionMode)
+                if (!typ.isOwned) {
                     logError(e, DisownUnowningExpressionError(e))
-                 }
+                }
 
-                 val newTyp = typ match {
-                     case n: NonPrimitiveType => n.residualType(ownershipConsumptionMode)
-                     case t => t
-                 }
+                val newTyp = typ match {
+                    case n: NonPrimitiveType => n.residualType(ownershipConsumptionMode)
+                    case t => t
+                }
 
-                 // If e is a variable, then we need to update the context to indicate that it's no longer owned.
-                 val finalContext = e match {
-                     case ReferenceIdentifier(x) =>
-                         if (contextPrime.lookupCurrentFieldTypeInThis(x).isDefined) {
-                             // This is a field.
-                             contextPrime.updatedThisFieldType(x, newTyp)
-                         }
-                         else {
-                             contextPrime.updated(x, newTyp)
-                         }
-                     case _ => contextPrime
-                 }
-                 (newTyp, finalContext, ePrime)
-             case StateInitializer(stateName, fieldName) =>
-                 // A state initializer expression has its field's type.
-                 if (!context.transitionFieldsDefinitelyInitialized.exists(
-                     {
-                         case (stateNameInitialized, fieldNameInitialized, _) =>
-                             (stateName._1 == stateNameInitialized && fieldName._1 == fieldNameInitialized)
-                     }))
-                     {
-                         logError(e, StateInitializerUninitialized(stateName._1, fieldName._1))
-                     }
+                // If e is a variable, then we need to update the context to indicate that it's no longer owned.
+                val finalContext = e match {
+                    case ReferenceIdentifier(x, obstype) =>
+                        if (contextPrime.lookupCurrentFieldTypeInThis(x).isDefined) {
+                            // This is a field.
+                            contextPrime.updatedThisFieldType(x, newTyp)
+                        }
+                        else {
+                            contextPrime.updated(x, newTyp)
+                        }
+                    case _ => contextPrime
+                }
+                (newTyp, finalContext, ePrime)
+            case StateInitializer(stateName, fieldName, obstype) =>
+                // A state initializer expression has its field's type.
+                if (!context.transitionFieldsDefinitelyInitialized.exists(
+                    {
+                        case (stateNameInitialized, fieldNameInitialized, _) =>
+                            (stateName._1 == stateNameInitialized && fieldName._1 == fieldNameInitialized)
+                    })) {
+                    logError(e, StateInitializerUninitialized(stateName._1, fieldName._1))
+                }
 
-                 val stateOption = context.contractTable.state(stateName._1)
-                 val fieldType = stateOption match {
-                     case None => logError(e, StateUndefinedError(context.contractTable.name, stateName._1)); BottomType()
-                     case Some(stateTable) =>
-                         stateTable.lookupField(fieldName._1) match {
-                             case None => logError(e, FieldUndefinedError(stateTable.nonPrimitiveType, fieldName._1)); BottomType()
-                             case Some(field) => field.typ
-                         }
-                 }
+                val stateOption = context.contractTable.state(stateName._1)
+                val fieldType = stateOption match {
+                    case None => logError(e, StateUndefinedError(context.contractTable.name, stateName._1)); BottomType()
+                    case Some(stateTable) =>
+                        stateTable.lookupField(fieldName._1) match {
+                            case None => logError(e, FieldUndefinedError(stateTable.nonPrimitiveType, fieldName._1)); BottomType()
+                            case Some(field) => field.typ
+                        }
+                }
 
-                 //assert(! e.obstype.isEmpty, s"infer and check failed to populate the type of ${e.toString}")
-                 (fieldType, context, e)
-         }
-
-        (retType, retCtx, updateType(retExp,retType))
+                //assert(! e.obstype.isEmpty, s"infer and check failed to populate the type of ${e.toString}")
+                (fieldType, context, e)
+        }
     }
 
 
     /* returns true if the sequence of statements includes a return statement, or an if/else statement
      * where both branches have return statements, and false otherwise
      */
-    private def hasReturnStatement(statements: Seq[Statement]) : Boolean = {
+    private def hasReturnStatement(statements: Seq[Statement]): Boolean = {
         var hasRet = false
 
         for (statement <- statements) {
@@ -1029,7 +1008,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         hasRet
     }
 
-    private def hasReturnStatementDontLog(statements: Seq[Statement]) : Boolean = {
+    private def hasReturnStatementDontLog(statements: Seq[Statement]): Boolean = {
         var hasRet = false
 
         for (statement <- statements) {
@@ -1047,7 +1026,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     /* returns true if the sequence of statements includes a state transition, or an if/else statement
     * where both branches have state transitions, and false otherwise
     */
-    private def hasTransition(statements: Seq[Statement]) : Boolean = {
+    private def hasTransition(statements: Seq[Statement]): Boolean = {
         var transition = false
 
         for (statement <- statements) {
@@ -1070,7 +1049,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         s.foldLeft((context, Seq.empty[Statement]))((prev: (Context, Seq[Statement]), s: Statement) => {
             val (newContext, newStatement) = checkStatement(decl, prev._1, s)
             (newContext, prev._2 :+ newStatement)
-            }
+        }
         )
     }
 
@@ -1098,8 +1077,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
             requiredFieldType match {
                 case None =>
-                    // The field doesn't exist, so there would have been another error generated previously.
-                    // Nothing to do here.
+                // The field doesn't exist, so there would have been another error generated previously.
+                // Nothing to do here.
                 case Some(declaredFieldType) =>
                     if (isSubtype(context.contractTable, typ, declaredFieldType, false).isEmpty &&
                         (typ.isOwned == declaredFieldType.isOwned || declaredFieldType.isBottom)) {
@@ -1132,7 +1111,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
             requiredFieldType match {
                 case None =>
-                    // Nothing to do; there was an assignment to a field type that may not be in scope, so there will be a separate error message.
+                // Nothing to do; there was an assignment to a field type that may not be in scope, so there will be a separate error message.
                 case Some(declaredFieldType) =>
                     if (isSubtype(context.contractTable, typ, declaredFieldType, false).isDefined || (typ.isOwned != declaredFieldType.isOwned && !declaredFieldType.isBottom)) {
                         logError(exitLocation, InvalidInconsistentFieldType(field, typ, declaredFieldType))
@@ -1200,11 +1179,11 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     // If a context exits, then allow discrepancies between variables, and take the version from the OTHER context.
     // If both contexts exit, and there is a discrepancy, just use the version from context 1, since the code below will be unreachable anyway.
     private def mergeContext(
-            ast: AST,
-            context1: Context,
-            context2: Context,
-            context1Exits: Boolean,
-            context2Exits: Boolean): Context = {
+                                ast: AST,
+                                context1: Context,
+                                context2: Context,
+                                context1Exits: Boolean,
+                                context2Exits: Boolean): Context = {
         /* If we're merging with a context from a "throw", just take the other context
         * emit no errors */
         assert(context1.contractTable == context2.contractTable)
@@ -1234,7 +1213,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         if (!t1.isBottom && !t2.isBottom) {
                             logError(ast, MergeIncompatibleError(x, t1, t2))
                         }
-                        // Otherwise, one is BottomType, so we can ignore the failure to merge for now.
+                    // Otherwise, one is BottomType, so we can ignore the failure to merge for now.
                 }
             }
 
@@ -1270,13 +1249,12 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         val mergedThisFieldMap = mergeMaps(packedContext1.thisFieldTypes, packedContext2.thisFieldTypes, false)
 
         // This is an intersect operation that only depends on the state and field names, not on the ASTs.
-        def mergeTransitionFieldsInitialized(fields1: Set[(String, String, AST)], fields2: Set[(String, String, AST)]) : Set[(String, String, AST)] = {
+        def mergeTransitionFieldsInitialized(fields1: Set[(String, String, AST)], fields2: Set[(String, String, AST)]): Set[(String, String, AST)] = {
             var resultingFields = Set[(String, String, AST)]()
             for (fieldInitialized <- fields1) {
-                if (fields2.exists( (otherFieldInitialized: (String, String, AST)) =>
+                if (fields2.exists((otherFieldInitialized: (String, String, AST)) =>
                     otherFieldInitialized._1 == fieldInitialized._1 &&
-                    otherFieldInitialized._2 == fieldInitialized._2))
-                {
+                        otherFieldInitialized._2 == fieldInitialized._2)) {
                     resultingFields = resultingFields + fieldInitialized
                 }
             }
@@ -1305,10 +1283,10 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
      * of identifiers on the path. If [e] isn't this form, returns None */
     private def extractPath(e: Expression): Option[Seq[String]] = {
         e match {
-            case ReferenceIdentifier(x) => Some(x::Nil)
-            case This() => Some("this"::Nil)
-            case Parent() => Some("this"::"parent"::Nil)
-            case Dereference(ePrime, f) => extractPath(ePrime).map(_ ++ (f::Nil))
+            case ReferenceIdentifier(x,_) => Some(x :: Nil)
+            case This(_) => Some("this" :: Nil)
+            case Parent() => Some("this" :: "parent" :: Nil)
+            case Dereference(ePrime, f) => extractPath(ePrime).map(_ ++ (f :: Nil))
             case _ => None
         }
     }
@@ -1316,18 +1294,18 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     // Returns [Left(errs)] if [spec] and [args] don't match, and returns [Right(context)] if they do.
     // Typechecks the arguments, and transfers ownership unless the spec is Unowned
     private def checkArgsWithSpec(
-            ast: AST,
-            decl: InvokableDeclaration,
-            context: Context,
-            spec: Seq[VariableDeclWithSpec],
-            args: Seq[Expression]): Either[Seq[(AST, Error)], (Seq[Expression], Context)] = {
+                                     ast: AST,
+                                     decl: InvokableDeclaration,
+                                     context: Context,
+                                     spec: Seq[VariableDeclWithSpec],
+                                     args: Seq[Expression]): Either[Seq[(AST, Error)], (Seq[Expression], Context)] = {
 
         var errList: List[(AST, Error)] = Nil
         val (specL, argsL) = (spec.length, args.length)
 
         if (specL != argsL) {
             val name = if (decl.isInstanceOf[Constructor]) s"constructor of ${decl.name}" else decl.name
-            Left((ast, WrongArityError(specL, argsL, name))::errList)
+            Left((ast, WrongArityError(specL, argsL, name)) :: errList)
         } else {
             var contextAfterArgs = context
             var expressionList = Seq[Expression]()
@@ -1337,8 +1315,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 val specOutputType = spec(i).typOut
 
                 val nameToUpdate = arg match {
-                    case ReferenceIdentifier(x) => Some(x)
-                    case This() => Some("this")
+                    case ReferenceIdentifier(x,_) => Some(x)
+                    case This(_) => Some("this")
                     case _ => None
                 }
 
@@ -1371,7 +1349,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 }
                 if (isSubtype(context.contractTable, argType, specInputType, false).isDefined) {
                     val err = ArgumentSubtypingError(decl.name, spec(i).varName, argType, specInputType)
-                    errList = (ast, err)::errList
+                    errList = (ast, err) :: errList
                 }
 
                 contextAfterArgs = contextAfterOwnershipTransfer
@@ -1386,10 +1364,10 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
     // checks the arguments based on possibly many specifications, such as multiple constructors
     // logs all errors at the end
     private def checkArgs(
-            ast: AST,
-            context: Context,
-            specs: Seq[(Seq[VariableDeclWithSpec], InvokableDeclaration)],
-            args: Seq[Expression]): Option[(Seq[Expression], Context, InvokableDeclaration)] = {
+                             ast: AST,
+                             context: Context,
+                             specs: Seq[(Seq[VariableDeclWithSpec], InvokableDeclaration)],
+                             args: Seq[Expression]): Option[(Seq[Expression], Context, InvokableDeclaration)] = {
 
         var errs: List[(AST, Error)] = Nil
         for ((spec, invokable) <- specs) {
@@ -1456,14 +1434,13 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                                        declaredFinalType: NonPrimitiveType,
                                        context: Context): Context = {
         val nameToUpdate = arg match {
-            case ReferenceIdentifier(x) => Some(x)
-            case This() => Some("this")
+            case ReferenceIdentifier(x,_) => Some(x)
+            case This(_) => Some("this")
             case _ =>
                 // If the argument isn't bound to a variable but owns an asset, and this call is not going to consume ownership, then error.
                 if (argType.isOwned && argType.isAssetReference(context.contractTable) != No() &&
                     (declaredFinalType.isOwned || !declaredInitialType.isOwned) &&
-                    argType.remoteReferenceType != TopLevelRemoteReferenceType())
-                {
+                    argType.remoteReferenceType != TopLevelRemoteReferenceType()) {
                     if (declaredInitialType.permission == Shared()) {
                         logError(arg, LostOwnershipErrorDueToSharing(arg))
                     }
@@ -1507,25 +1484,25 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
             val (variableType, isField) =
                 localVariableType match {
-                case None =>
-                    // Not a local variable. Maybe a field?
-                    val fieldType = contextPrime.lookupCurrentFieldTypeInThis(x)
+                    case None =>
+                        // Not a local variable. Maybe a field?
+                        val fieldType = contextPrime.lookupCurrentFieldTypeInThis(x)
 
-                    /* if it's not a field either, log an error */
-                    fieldType match {
-                        case None =>
-                            if (mustBeField) {
-                                logError(s, FieldUndefinedError(contextPrime.thisType, x))
-                            }
-                            else {
-                                logError(s, VariableUndefinedError(x, contextPrime.thisType.toString))
-                            }
-                            (BottomType(), false)
-                        case Some(typ) => (typ, true)
-                    }
-                case Some(typ) =>
-                    // Local variable.
-                    (typ, false)
+                        /* if it's not a field either, log an error */
+                        fieldType match {
+                            case None =>
+                                if (mustBeField) {
+                                    logError(s, FieldUndefinedError(contextPrime.thisType, x))
+                                }
+                                else {
+                                    logError(s, VariableUndefinedError(x, contextPrime.thisType.toString))
+                                }
+                                (BottomType(), false)
+                            case Some(typ) => (typ, true)
+                        }
+                    case Some(typ) =>
+                        // Local variable.
+                        (typ, false)
                 }
 
             val contextWithAssignmentUpdate =
@@ -1670,7 +1647,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 val (typ, contextPrime, ePrime) = inferAndCheckExpr(decl, context, e, consumeOwnership)
 
                 val thisSetToExclude = e match {
-                    case ReferenceIdentifier(xOther)
+                    case ReferenceIdentifier(xOther,_)
                         if retTypeOpt.isDefined && retTypeOpt.get.isOwned => Set(xOther, "this")
                     case _ => Set("this")
                 }
@@ -1729,7 +1706,6 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     allFields.filter((f: Field) =>
                         f.availableIn.isEmpty || f.availableIn.get.contains(stateName))
                 }
-
 
 
                 val definiteCurrentFields = // These are definitely available now.
@@ -1796,7 +1772,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 if (updates.isDefined) {
                     var newUpdates = Seq.empty[(ReferenceIdentifier, Expression)]
 
-                    for ((ReferenceIdentifier(f), e) <- updates.get) {
+                    for ((ReferenceIdentifier(f,_), e) <- updates.get) {
                         // Check to make sure we're not going to lose an owned asset by overwriting it
                         val currentFieldType = contextPrime.lookupCurrentFieldTypeInThis(f).getOrElse(BottomType())
                         if (currentFieldType.isAssetReference(thisTable) != No() && currentFieldType.isOwned) {
@@ -1807,7 +1783,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         val fieldAST = newStateTable.lookupField(f)
                         if (fieldAST.isDefined) {
                             val (t, contextPrime2, ePrime) = inferAndCheckExpr(decl, contextPrime, e, consumptionModeForType(fieldAST.get.typ))
-                            newUpdates = newUpdates :+ (ReferenceIdentifier(f), ePrime)
+                            newUpdates = newUpdates :+ (ReferenceIdentifier(f,t), ePrime)
                             contextPrime = contextPrime2
                             checkIsSubtype(contextPrime.contractTable, s, t, fieldAST.get.typ)
                         }
@@ -1826,12 +1802,12 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     // fields will not have been initialized yet, so that's fine.
                     val fieldsFromPossibleStates = possibleCurrentStates.map(fieldsAvailableInState).reduce(
                         (s1: Set[Field], s2: Set[Field]) => s1 union s2)
-                    val uninitializedConstructorFieldNames = context.thisFieldTypes.filter( (field: (String, ObsidianType)) =>
+                    val uninitializedConstructorFieldNames = context.thisFieldTypes.filter((field: (String, ObsidianType)) =>
                         field._2 match {
                             case np: NonPrimitiveType => np.permission == Inferred()
                             case _ => false
                         }).keys
-                    fieldsFromPossibleStates.filter( (f: Field) => !uninitializedConstructorFieldNames.exists(f.name.equals))
+                    fieldsFromPossibleStates.filter((f: Field) => !uninitializedConstructorFieldNames.exists(f.name.equals))
                 }
                 val toCheckForDroppedAssets = possibleCurrentFields -- newFields // fields that we might currently have minus fields we're initializing now
                 for (oldField <- toCheckForDroppedAssets) {
@@ -1847,7 +1823,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 var newThisFieldTypes = contextPrime.thisFieldTypes.filter((fieldType: (String, ObsidianType)) => newFieldNames.contains(fieldType._1))
 
                 // Discard records for any this-field types that we're about to assign to.
-                for ((ReferenceIdentifier(f), e) <- updates.getOrElse(Seq())) {
+                for ((ReferenceIdentifier(f,_), e) <- updates.getOrElse(Seq())) {
                     newThisFieldTypes = newThisFieldTypes - f
                 }
                 // Discard records for any this-field types for which there were initializers (S::x = ...)
@@ -1877,15 +1853,16 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
                 (contextAfterTransition, Transition(newStateName, newUpdatesOption, context.thisType.permission).setLoc(s))
 
-            case Assignment(ReferenceIdentifier(x), e: Expression) =>
+            case Assignment(ReferenceIdentifier(x,obstyp), e: Expression) =>
                 if (context.valVariables.contains(x)) {
                     logError(s, InvalidValAssignmentError())
                 }
                 val (contextPrime, statementPrime, ePrime) = checkAssignment(x, e, context, false)
-                (contextPrime, Assignment(ReferenceIdentifier(x), ePrime).setLoc(s))
+                (contextPrime, Assignment(ReferenceIdentifier(x,obstyp), ePrime).setLoc(s))
 
             case Assignment(Dereference(eDeref, f), e: Expression) =>
-                if (eDeref != This()) {
+                assert(false, "the code below this case is certainly wrong and will need to be debugged on an example")
+                if (eDeref != This(eDeref.obstype.get)) { //todo: this is totally wrong again, i seem not to know how to get the type for `this`
                     logError(s, InvalidNonThisFieldAssignment())
                     (context, s)
                 }
@@ -1893,7 +1870,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     val (contextPrime, statementPrime, ePrime) = checkAssignment(f, e, context, true)
                     (contextPrime, Assignment(Dereference(eDeref, f), ePrime).setLoc(s))
                 }
-            case Assignment(StateInitializer(stateName, fieldIdentifier), e) =>
+            case Assignment(StateInitializer(stateName, fieldIdentifier, obstyp), e) =>
                 val stateOption = context.contractTable.state(stateName._1)
                 val declaredFieldType = stateOption match {
                     case None => logError(s, StateUndefinedError(context.contractTable.name, stateName._1)); BottomType()
@@ -1909,7 +1886,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 // If there might have been a prior initialization, make sure this initialization doesn't discard a
                 // nondisposable reference.
                 if (declaredFieldType.isOwned && declaredFieldType.isAssetReference(context.contractTable) != No() &&
-                    context.transitionFieldsMaybeInitialized.exists({ case (sn, fn, _) => sn == stateName._1 && fn == fieldIdentifier._1})) {
+                    context.transitionFieldsMaybeInitialized.exists({ case (sn, fn, _) => sn == stateName._1 && fn == fieldIdentifier._1 })) {
                     logError(s, OverwrittenOwnershipError(fieldIdentifier._1))
                 }
 
@@ -1919,7 +1896,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 }
                 else {
                     (contextPrime.updatedWithTransitionInitialization(stateName._1, fieldIdentifier._1, s),
-                      Assignment(StateInitializer(stateName, fieldIdentifier), ePrime))
+                        Assignment(StateInitializer(stateName, fieldIdentifier, t), ePrime))
+                    // todo: again i don't know which one to prefer or what to do if they're disequal
                 }
 
             // assignment target is neither a variable nor a field
@@ -1979,7 +1957,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         np.contractName
                     case p: PrimitiveType =>
                         if (!t.isBottom) {
-                          logError(e, StateCheckOnPrimitiveError())
+                            logError(e, StateCheckOnPrimitiveError())
                         }
                         // There was previously some kind of error. Don't propagate it.
                         return (contextPrime, IfInState(ePrime, ePerm, state, body1, body2).setLoc(s))
@@ -2013,8 +1991,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                             val ident = e match {
                                 // If e is a variable, we might be able to put it in the context with the appropriate state.
                                 // If it's not a variable, we just check the state and move on (no context changes).
-                                case ReferenceIdentifier(x) => Some(x)
-                                case This() => Some("this")
+                                case ReferenceIdentifier(x,_) => Some(x)
+                                case This(_) => Some("this")
                                 case _ => None
                             }
 
@@ -2036,6 +2014,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                                             // This is a local variable, so just update it.
                                             contextPrime.updated(x, newType).updatedMakingVariableVal(x)
                                         }
+
                                     def falseBranchContext(typeFalse: ObsidianType) =
                                         if (exprIsField) {
                                             contextPrime.updatedThisFieldType(x, typeFalse).updatedMakingVariableVal(x)
@@ -2089,17 +2068,17 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 // Ensure that the variable that was checked retains ownership (was not given away) in the true branch.
                 resetOwnership match {
                     case None => () // Nothing to do
-                    case Some ((x, oldType)) =>
+                    case Some((x, oldType)) =>
                         val newType = if (exprIsField) trueContext.thisFieldTypes.get(x) else trueContext.get(x)
                         newType match {
-                        case None => () // OK; fields that are consistent with their declarations may not be in here anymore.
-                        case Some(newType) => newType match {
-                            case np: NonPrimitiveType => if (np.permission == Unowned()) {
-                                logError(s, InvalidOwnershipLossInDynamicCheck(x))
+                            case None => () // OK; fields that are consistent with their declarations may not be in here anymore.
+                            case Some(newType) => newType match {
+                                case np: NonPrimitiveType => if (np.permission == Unowned()) {
+                                    logError(s, InvalidOwnershipLossInDynamicCheck(x))
+                                }
+                                case _ => assert(false, "Nonprimitive type should not become primitive in branch.");
                             }
-                            case _ => assert(false, "Nonprimitive type should not become primitive in branch.");
                         }
-                    }
                 }
 
                 val packedTrueContext = packFieldTypes(trueContext)
@@ -2183,19 +2162,19 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         return (contextPrime, Switch(ePrime, cases).setLoc(s))
                 }
 
-                def checkSwitchCase(sc: SwitchCase) : (Context, SwitchCase) = {
+                def checkSwitchCase(sc: SwitchCase): (Context, SwitchCase) = {
                     val newType: ObsidianType = t.withTypeState(States(Set(sc.stateName)))
 
                     /* special case to allow types to change in the context if we match on a variable */
                     val startContext = e match {
-                        case This() =>
+                        case This(obstyp) =>
                             /* reading "this" as an expression takes the residual of "this",
                              * so we want "this" in the context to have the old permission of
                              * "this" with the new state information in the unpermissioned type */
                             val newContextThisType =
                                 newType // is this right?
                             contextPrime.updated("this", newContextThisType)
-                        case ReferenceIdentifier(x) =>
+                        case ReferenceIdentifier(x,_) =>
                             if (contextPrime.get(x).isDefined) {
                                 // We're switching on a local variable or formal parameter.
                                 contextPrime.updated(x, newType)
@@ -2238,7 +2217,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 (mergedContext, Switch(ePrime, newCases).setLoc(s))
 
             // TODO maybe allow constructors as statements later, but it's not very important
-            case d@Disown (e) =>
+            case d@Disown(e) =>
                 val (typ, contextPrime, ePrime) = inferAndCheckExpr(decl, context, d, ConsumingOwnedGivesShared())
                 (contextPrime, Disown(ePrime).setLoc(s))
             case e: Expression =>
@@ -2265,7 +2244,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     }
                 }
 
-                def allValidStates(contractName: String) : Set[String] = {
+                def allValidStates(contractName: String): Set[String] = {
                     val contractType = context.contractTable.lookupContract(contractName).get
                     contractType.possibleStates
                 }
@@ -2529,7 +2508,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     val stateName = stateNames.head
 
                     lexicallyInsideOf.contractTable.state(stateName) match {
-                        case Some (t) => t
+                        case Some(t) => t
                         case None => lexicallyInsideOf
                     }
                 }
@@ -2541,13 +2520,13 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
         // Construct the context that the body should start with
         var initContext = Context(table,
-                                  new TreeMap[String, ObsidianType](),
-                                  isThrown = false,
-                                  Set.empty,
-                                  Set.empty,
-                                  Set.empty,
-                                  tx.initialFieldTypes,
-                                  tx.args.map((v: VariableDeclWithSpec) => v.varName).toSet)
+            new TreeMap[String, ObsidianType](),
+            isThrown = false,
+            Set.empty,
+            Set.empty,
+            Set.empty,
+            tx.initialFieldTypes,
+            tx.args.map((v: VariableDeclWithSpec) => v.varName).toSet)
         initContext = initContext.updated("this", thisType)
 
         // Add all the args first (in an unsafe way) before checking anything
@@ -2561,9 +2540,9 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             case Some(typ) =>
                 typ match {
                     case np: NonPrimitiveType =>
-                         if (np.permission == Inferred()) {
-                             logError(tx, ReturnTypeMissingPermissionError(np.contractName))
-                         }
+                        if (np.permission == Inferred()) {
+                            logError(tx, ReturnTypeMissingPermissionError(np.contractName))
+                        }
                     case _ => ()
                 }
             case _ => ()
@@ -2650,7 +2629,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
     private def checkConstructor(constr: Constructor, table: ContractTable, hasStates: Boolean): Constructor = {
         // maybe this error should be handled in the parser
-        if(constr.name != table.name) {
+        if (constr.name != table.name) {
             logError(constr, ConstructorNameError(table.name))
         }
 
@@ -2660,13 +2639,13 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
         val stateSet: Set[(String, StateTable)] = table.stateLookup.toSet
         var initContext = Context(table,
-                                  new TreeMap[String, ObsidianType](),
-                                  isThrown = false,
-                                  Set.empty,
-                                  Set.empty,
-                                  Set.empty,
-                                  Map.empty,
-                                  constr.args.map((v: VariableDeclWithSpec) => v.varName).toSet)
+            new TreeMap[String, ObsidianType](),
+            isThrown = false,
+            Set.empty,
+            Set.empty,
+            Set.empty,
+            Map.empty,
+            constr.args.map((v: VariableDeclWithSpec) => v.varName).toSet)
 
         val thisType = ContractReferenceType(table.contractType, Owned(), NotRemoteReferenceType())
 
@@ -2717,7 +2696,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         }
 
         val expectedThisType: NonPrimitiveType = constr.resultType
-        val thisAST = This().setLoc(constr.loc) // Make a fake "this" AST so we generate the right error message.
+        val thisAST = This(StringType()).setLoc(constr.loc) // Make a fake "this" AST so we generate the right error message.
+        // todo: this is fake, i know even less about what to put there!
         checkIsSubtype(table, thisAST, outputContext("this"), expectedThisType, true)
 
         checkForUnusedOwnershipErrors(constr, outputContext, Set("this"))
@@ -2763,18 +2743,22 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
             ((arg1.typIn, arg2.typIn) match {
                 case (t1: NonPrimitiveType, t2: NonPrimitiveType) =>
                     (t1.permission, t2.permission) match {
-                        case (Unowned(), p)     => Some(s"${t2.contractName}@${p.toString}")
-                        case (p, Unowned())     => Some(s"${t2.contractName}@${p.toString}")
-                        case (Shared(), p)      => Some(s"${t2.contractName}@${p.toString}")
-                        case (p, Shared())      => Some(s"${t2.contractName}@${p.toString}")
+                        case (Unowned(), p) => Some(s"${t2.contractName}@${p.toString}")
+                        case (p, Unowned()) => Some(s"${t2.contractName}@${p.toString}")
+                        case (Shared(), p) => Some(s"${t2.contractName}@${p.toString}")
+                        case (p, Shared()) => Some(s"${t2.contractName}@${p.toString}")
                         case (Owned(), Owned()) =>
                             table.possibleStatesFor(t1).intersect(table.possibleStatesFor(t2)).headOption.map(state => s"${t1.contractName}@$state")
-                        case _                  => None
+                        case _ => None
                     }
 
                 // Should always (?) fail, since we grouped on type name (e.g., int is never distinguishable from another int)
                 case (t1: PrimitiveType, t2: PrimitiveType) =>
-                    if (t1.toString != t2.toString) { None } else { Some(t1.toString) }
+                    if (t1.toString != t2.toString) {
+                        None
+                    } else {
+                        Some(t1.toString)
+                    }
                 case (BottomType(), _) => None
                 case (_, BottomType()) => None
                 // This case should never happen, since we already grouped the constructor arguments on type
@@ -2783,7 +2767,11 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
         // https://stackoverflow.com/a/6751877/1498618
         def sequence[A](opts: Seq[Option[A]]): Option[Seq[A]] =
-            if (opts.contains(None)) { None } else { Some(opts.flatten) }
+            if (opts.contains(None)) {
+                None
+            } else {
+                Some(opts.flatten)
+            }
 
         // Returns the first argument pair that is ambiguous, if EVERY argument pair is ambiguous
         // If any pair is distinguishable, that means the constructors are themselves distinguishable
@@ -2979,8 +2967,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
         checkForMainContract(globalTable.ast)
 
         var checkDiffContract = (x: Contract) => x match {
-            case obsContract : ObsidianContractImpl => checkContract(obsContract)
-            case ffiContract : JavaFFIContractImpl => ffiContract
+            case obsContract: ObsidianContractImpl => checkContract(obsContract)
+            case ffiContract: JavaFFIContractImpl => ffiContract
         }
 
         checkForDuplicateTopDecl(globalTable.ast.contracts)

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1283,7 +1283,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
      * of identifiers on the path. If [e] isn't this form, returns None */
     private def extractPath(e: Expression): Option[Seq[String]] = {
         e match {
-            case ReferenceIdentifier(x,_) => Some(x :: Nil)
+            case ReferenceIdentifier(x, _) => Some(x :: Nil)
             case This(_) => Some("this" :: Nil)
             case Parent() => Some("this" :: "parent" :: Nil)
             case Dereference(ePrime, f) => extractPath(ePrime).map(_ ++ (f :: Nil))
@@ -1315,7 +1315,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 val specOutputType = spec(i).typOut
 
                 val nameToUpdate = arg match {
-                    case ReferenceIdentifier(x,_) => Some(x)
+                    case ReferenceIdentifier(x, _) => Some(x)
                     case This(_) => Some("this")
                     case _ => None
                 }
@@ -1434,7 +1434,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                                        declaredFinalType: NonPrimitiveType,
                                        context: Context): Context = {
         val nameToUpdate = arg match {
-            case ReferenceIdentifier(x,_) => Some(x)
+            case ReferenceIdentifier(x, _) => Some(x)
             case This(_) => Some("this")
             case _ =>
                 // If the argument isn't bound to a variable but owns an asset, and this call is not going to consume ownership, then error.
@@ -1647,7 +1647,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 val (typ, contextPrime, ePrime) = inferAndCheckExpr(decl, context, e, consumeOwnership)
 
                 val thisSetToExclude = e match {
-                    case ReferenceIdentifier(xOther,_)
+                    case ReferenceIdentifier(xOther, _)
                         if retTypeOpt.isDefined && retTypeOpt.get.isOwned => Set(xOther, "this")
                     case _ => Set("this")
                 }
@@ -1772,7 +1772,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 if (updates.isDefined) {
                     var newUpdates = Seq.empty[(ReferenceIdentifier, Expression)]
 
-                    for ((ReferenceIdentifier(f,_), e) <- updates.get) {
+                    for ((ReferenceIdentifier(f, _), e) <- updates.get) {
                         // Check to make sure we're not going to lose an owned asset by overwriting it
                         val currentFieldType = contextPrime.lookupCurrentFieldTypeInThis(f).getOrElse(BottomType())
                         if (currentFieldType.isAssetReference(thisTable) != No() && currentFieldType.isOwned) {
@@ -1783,7 +1783,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         val fieldAST = newStateTable.lookupField(f)
                         if (fieldAST.isDefined) {
                             val (t, contextPrime2, ePrime) = inferAndCheckExpr(decl, contextPrime, e, consumptionModeForType(fieldAST.get.typ))
-                            newUpdates = newUpdates :+ (ReferenceIdentifier(f,Some(t)), ePrime)
+                            newUpdates = newUpdates :+ (ReferenceIdentifier(f, Some(t)), ePrime)
                             contextPrime = contextPrime2
                             checkIsSubtype(contextPrime.contractTable, s, t, fieldAST.get.typ)
                         }
@@ -1823,7 +1823,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 var newThisFieldTypes = contextPrime.thisFieldTypes.filter((fieldType: (String, ObsidianType)) => newFieldNames.contains(fieldType._1))
 
                 // Discard records for any this-field types that we're about to assign to.
-                for ((ReferenceIdentifier(f,_), e) <- updates.getOrElse(Seq())) {
+                for ((ReferenceIdentifier(f, _), e) <- updates.getOrElse(Seq())) {
                     newThisFieldTypes = newThisFieldTypes - f
                 }
                 // Discard records for any this-field types for which there were initializers (S::x = ...)
@@ -1853,12 +1853,12 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
                 (contextAfterTransition, Transition(newStateName, newUpdatesOption, context.thisType.permission).setLoc(s))
 
-            case Assignment(ReferenceIdentifier(x,obstyp), e: Expression) =>
+            case Assignment(ReferenceIdentifier(x, obstyp), e: Expression) =>
                 if (context.valVariables.contains(x)) {
                     logError(s, InvalidValAssignmentError())
                 }
                 val (contextPrime, statementPrime, ePrime) = checkAssignment(x, e, context, false)
-                (contextPrime, Assignment(ReferenceIdentifier(x,obstyp), ePrime).setLoc(s))
+                (contextPrime, Assignment(ReferenceIdentifier(x, obstyp), ePrime).setLoc(s))
 
             case Assignment(Dereference(eDeref, f), e: Expression) =>
                 assert(false, "the code below this case is certainly wrong and will need to be debugged on an example")
@@ -1991,7 +1991,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                             val ident = e match {
                                 // If e is a variable, we might be able to put it in the context with the appropriate state.
                                 // If it's not a variable, we just check the state and move on (no context changes).
-                                case ReferenceIdentifier(x,_) => Some(x)
+                                case ReferenceIdentifier(x, _) => Some(x)
                                 case This(_) => Some("this")
                                 case _ => None
                             }
@@ -2174,7 +2174,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                             val newContextThisType =
                                 newType // is this right?
                             contextPrime.updated("this", newContextThisType)
-                        case ReferenceIdentifier(x,_) =>
+                        case ReferenceIdentifier(x, _) =>
                             if (contextPrime.get(x).isDefined) {
                                 // We're switching on a local variable or formal parameter.
                                 contextPrime.updated(x, newType)

--- a/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
@@ -148,7 +148,7 @@ class IdentityAstTransformer {
             case s: StringLiteral => (s, List())
             case t: TrueLiteral => (TrueLiteral().setLoc(t), List())
             case f: FalseLiteral => (FalseLiteral().setLoc(f), List())
-            case t: This => (This().setLoc(t), List())
+            case t: This => (This(None).setLoc(t), List()) // todo: no idea if this is right
             case p: Parent => (Parent().setLoc(p), List())
             case c: Conjunction =>
                 transformBinary(table, lexicallyInsideOf, context, c.e1, c.e2, params, Conjunction(_, _).setLoc(c))

--- a/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
@@ -148,7 +148,7 @@ class IdentityAstTransformer {
             case s: StringLiteral => (s, List())
             case t: TrueLiteral => (TrueLiteral().setLoc(t), List())
             case f: FalseLiteral => (FalseLiteral().setLoc(f), List())
-            case t: This => (This(None).setLoc(t), List()) // todo: no idea if this is right
+            case t: This => (This(t.obstype).setLoc(t), List())
             case p: Parent => (Parent().setLoc(p), List())
             case c: Conjunction =>
                 transformBinary(table, lexicallyInsideOf, context, c.e1, c.e2, params, Conjunction(_, _).setLoc(c))

--- a/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
@@ -114,10 +114,10 @@ class IdentityAstTransformer {
     }
 
     def transformField(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            f: Field): (Field, Seq[ErrorRecord]) = {
-        val thisType =  ContractReferenceType(lexicallyInsideOf.contractType, Owned(), NotRemoteReferenceType())
+                          table: SymbolTable,
+                          lexicallyInsideOf: DeclarationTable,
+                          f: Field): (Field, Seq[ErrorRecord]) = {
+        val thisType = ContractReferenceType(lexicallyInsideOf.contractType, Owned(), NotRemoteReferenceType())
 
         val context = startContext(lexicallyInsideOf, List.empty, thisType) // Permission of this is irrelevant when transforming fields
         val (newType, errors) = transformType(table, lexicallyInsideOf, context, f.typ, f.loc, Nil)
@@ -155,7 +155,7 @@ class IdentityAstTransformer {
             case d: Disjunction =>
                 transformBinary(table, lexicallyInsideOf, context, d.e1, d.e2, params, Disjunction(_, _).setLoc(d))
             case n: LogicalNegation =>
-               transformUnary(table, lexicallyInsideOf, context, n.e, params, LogicalNegation(_).setLoc(n))
+                transformUnary(table, lexicallyInsideOf, context, n.e, params, LogicalNegation(_).setLoc(n))
             case a: Add =>
                 transformBinary(table, lexicallyInsideOf, context, a.e1, a.e2, params, Add(_, _).setLoc(a))
             case a: StringConcat =>
@@ -199,8 +199,8 @@ class IdentityAstTransformer {
                     i.args.map(transformExpression(table, lexicallyInsideOf, context, _, params)).unzip
                 (i.copy(recipient = newRecipient, args = newArgs, params = newParams).setLoc(i),
                     recipientErrors ++
-                    errors.flatten.toList ++
-                    argErrors.flatten.toList)
+                        errors.flatten.toList ++
+                        argErrors.flatten.toList)
 
             case c: Construction =>
                 val (newParams, errors) =
@@ -227,11 +227,11 @@ class IdentityAstTransformer {
     }
 
     def transformArgs(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            args: Seq[VariableDeclWithSpec],
-            thisType: ObsidianType,
-            params: Seq[GenericType]): (Seq[VariableDeclWithSpec], Seq[ErrorRecord]) = {
+                         table: SymbolTable,
+                         lexicallyInsideOf: DeclarationTable,
+                         args: Seq[VariableDeclWithSpec],
+                         thisType: ObsidianType,
+                         params: Seq[GenericType]): (Seq[VariableDeclWithSpec], Seq[ErrorRecord]) = {
         var errors = List.empty[ErrorRecord]
         var newArgs: Seq[VariableDeclWithSpec] = Nil
         val context = startContext(lexicallyInsideOf, args, thisType)
@@ -260,15 +260,15 @@ class IdentityAstTransformer {
     }
 
     def transformTransaction(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            t: Transaction): (Transaction, Seq[ErrorRecord]) = {
+                                table: SymbolTable,
+                                lexicallyInsideOf: DeclarationTable,
+                                t: Transaction): (Transaction, Seq[ErrorRecord]) = {
         val context = startContext(lexicallyInsideOf, t.args, t.thisType)
 
         // TODO GENERIC: Maybe there's a better way. We need to ensure we return a nonprimitivetype,
         //  but we also need to transform thisType to handle generic parameters properly
         val (newThisType, thisTypeErrors) =
-            requireNonPrimitive(t.thisType, lexicallyInsideOf, t.loc, transformType(table, lexicallyInsideOf, context, t.thisType, t.loc, t.params))
+        requireNonPrimitive(t.thisType, lexicallyInsideOf, t.loc, transformType(table, lexicallyInsideOf, context, t.thisType, t.loc, t.params))
         val (newThisFinalType, thisFinalTypeErrors) =
             requireNonPrimitive(t.thisFinalType, lexicallyInsideOf, t.loc, transformType(table, lexicallyInsideOf, context, t.thisFinalType, t.loc, t.params))
 
@@ -285,7 +285,7 @@ class IdentityAstTransformer {
                 val (transformedType, errs) = transformType(table, lexicallyInsideOf, context, retType, t.loc, t.params)
                 (Some(transformedType), errs)
         }
-        val (newTransactionBody, _, bodyErrors) =  transformBody(table, lexicallyInsideOf, context, t.body, t.params)
+        val (newTransactionBody, _, bodyErrors) = transformBody(table, lexicallyInsideOf, context, t.body, t.params)
         val newTransaction =
             t.copy(retType = newRetType,
                 thisType = newThisType,
@@ -295,13 +295,13 @@ class IdentityAstTransformer {
                 body = newTransactionBody).setLoc(t)
         (newTransaction,
             thisTypeErrors ++ thisFinalTypeErrors ++ retTypeErrors ++
-            argErrors ++ allEnsureErrors.flatten.toList ++ bodyErrors)
+                argErrors ++ allEnsureErrors.flatten.toList ++ bodyErrors)
     }
 
     def transformConstructor(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            c: Constructor): (Constructor, Seq[ErrorRecord]) = {
+                                table: SymbolTable,
+                                lexicallyInsideOf: DeclarationTable,
+                                c: Constructor): (Constructor, Seq[ErrorRecord]) = {
 
         val (newResultType, resTypeErrors) =
             requireNonPrimitive(c.resultType, lexicallyInsideOf, c.loc,
@@ -319,11 +319,11 @@ class IdentityAstTransformer {
     }
 
     def transformBody(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            inScope: Context,
-            b: Seq[Statement],
-            params: Seq[GenericType]): (Seq[Statement], Context, Seq[ErrorRecord]) = {
+                         table: SymbolTable,
+                         lexicallyInsideOf: DeclarationTable,
+                         inScope: Context,
+                         b: Seq[Statement],
+                         params: Seq[GenericType]): (Seq[Statement], Context, Seq[ErrorRecord]) = {
         b match {
             case Seq() => (Seq(), inScope, Seq())
             case s +: rest =>
@@ -334,11 +334,11 @@ class IdentityAstTransformer {
     }
 
     def transformStatement(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            context: Context,
-            s: Statement,
-            params: Seq[GenericType]): (Statement, Context, Seq[ErrorRecord]) = {
+                              table: SymbolTable,
+                              lexicallyInsideOf: DeclarationTable,
+                              context: Context,
+                              s: Statement,
+                              params: Seq[GenericType]): (Statement, Context, Seq[ErrorRecord]) = {
         s match {
             case oldDecl@VariableDecl(typ, varName) =>
                 val (newTyp, errors) = transformType(table, lexicallyInsideOf, context, typ, s.loc, params)
@@ -433,16 +433,16 @@ class IdentityAstTransformer {
     }
 
     def transformTypeState(table: SymbolTable, lexicallyInsideOf: DeclarationTable, typeState: TypeState,
-                       pos: Position, params: Seq[GenericType]): (TypeState, List[ErrorRecord]) =
+                           pos: Position, params: Seq[GenericType]): (TypeState, List[ErrorRecord]) =
         (typeState, List())
 
     def transformType(
-            table: SymbolTable,
-            lexicallyInsideOf: DeclarationTable,
-            context: Context,
-            t: ObsidianType,
-            pos: Position,
-            params: Seq[GenericType]): (ObsidianType, List[ErrorRecord]) = {
+                         table: SymbolTable,
+                         lexicallyInsideOf: DeclarationTable,
+                         context: Context,
+                         t: ObsidianType,
+                         pos: Position,
+                         params: Seq[GenericType]): (ObsidianType, List[ErrorRecord]) = {
         (t, List.empty[ErrorRecord])
     }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/tests/TypeCheckerTests.scala
@@ -194,7 +194,7 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def equalityTest(): Unit = {
         runTest("resources/tests/type_checker_tests/Equality.obs",
-            (DifferentTypeError(ReferenceIdentifier("a"), IntType(), ReferenceIdentifier("b"), StringType()), 12)
+            (DifferentTypeError(ReferenceIdentifier("a", Some(IntType())), IntType(), ReferenceIdentifier("b", Some(StringType())), StringType()), 12)
                 ::
                 (DifferentTypeError(
                     TrueLiteral(),
@@ -322,13 +322,13 @@ class TypeCheckerTests extends JUnitSuite {
 
     @Test def sideEffectTest(): Unit = {
         runTest("resources/tests/type_checker_tests/NoSideEffects.obs",
-            (NoEffectsError(ReferenceIdentifier("x")), 8)
+            (NoEffectsError(ReferenceIdentifier("x", Some(IntType()))), 8)
                 ::
                 (NoEffectsError(
                     Add(NumLiteral(1), NumLiteral(3))), 10)
                 ::
                 (NoEffectsError(
-                    LessThan(NumLiteral(1), ReferenceIdentifier("x"))), 12)
+                    LessThan(NumLiteral(1), ReferenceIdentifier("x", Some(IntType())))), 12)
                 ::
                 (NoEffectsError(
                     Disjunction(TrueLiteral(), FalseLiteral())), 14)
@@ -475,7 +475,7 @@ class TypeCheckerTests extends JUnitSuite {
                     ContractReferenceType(ContractType("Money", Nil), Owned(), NotRemoteReferenceType())),
                     56)
                 ::
-                (DisownUnowningExpressionError(ReferenceIdentifier("m")), 49)
+                (DisownUnowningExpressionError(ReferenceIdentifier("m", Some(IntType()))), 49)
                 ::
                 (UnusedOwnershipError("m"), 72)
                 ::
@@ -590,10 +590,10 @@ class TypeCheckerTests extends JUnitSuite {
     @Test def staticAssertsTest(): Unit = {
         runTest("resources/tests/type_checker_tests/StaticAsserts.obs",
             (StaticAssertInvalidState("C", "S3"), 6)
-                ::
-                (StaticAssertFailed(This(), States(Set("S2")), StateType(ContractType("C", Nil), Set("S1", "S2"), NotRemoteReferenceType())), 17)
-                ::
-                (StaticAssertFailed(ReferenceIdentifier("ow"), Unowned(), ContractReferenceType(ContractType("C", Nil), Owned(), NotRemoteReferenceType())), 24)
+                :: // todo This(None) is suspect
+                (StaticAssertFailed(This(None), States(Set("S2")), StateType(ContractType("C", Nil), Set("S1", "S2"), NotRemoteReferenceType())), 17)
+                :: // todo i don't know what to put here either
+                (StaticAssertFailed(ReferenceIdentifier("ow", None), Unowned(), ContractReferenceType(ContractType("C", Nil), Owned(), NotRemoteReferenceType())), 24)
                 ::
                 Nil
         )
@@ -686,10 +686,10 @@ class TypeCheckerTests extends JUnitSuite {
             (StateCheckOnPrimitiveError(), 45) ::
               (StateCheckRedundant(), 56) ::
               (StaticAssertFailed(
-                ReferenceIdentifier("s"), Owned(),
+                ReferenceIdentifier("s", None), Owned(), // todo
                 StateType(ContractType("LightSwitch", Nil), "On", NotRemoteReferenceType())), 62) ::
               (StateCheckRedundant(), 67) ::
-                (StaticAssertFailed(ReferenceIdentifier("next"), States(Set("S1")),
+                (StaticAssertFailed(ReferenceIdentifier("next", None), States(Set("S1")),// todo
                     ContractReferenceType(ContractType("TestFieldShared", Nil), Shared(), NotRemoteReferenceType())), 88) ::
               Nil)
 
@@ -909,8 +909,8 @@ class TypeCheckerTests extends JUnitSuite {
             (ReceiverTypeIncompatibleError("t5",
                 ContractReferenceType(ContractType("PermissionPassing", Nil), Unowned(), NotRemoteReferenceType()),
                 ContractReferenceType(ContractType("PermissionPassing", Nil), Owned(), NotRemoteReferenceType())), 47) ::
-                (UnusedExpressionArgumentOwnershipError(LocalInvocation("returnOwnedAsset", Nil, Nil, Nil)), 58) ::
-                (LostOwnershipErrorDueToSharing(LocalInvocation("returnOwnedAsset", Nil, Nil, Nil)), 65) ::
+                (UnusedExpressionArgumentOwnershipError(LocalInvocation("returnOwnedAsset", Nil, Nil, Nil, None)), 58) :: // todo this may need to be an encoding of the type of returnOwnedAsset
+                (LostOwnershipErrorDueToSharing(LocalInvocation("returnOwnedAsset", Nil, Nil, Nil, None)), 65) :: // todo ditto
                 Nil)
     }
 
@@ -922,8 +922,8 @@ class TypeCheckerTests extends JUnitSuite {
                     ContractReferenceType(ContractType("AllPermissions", Nil), Owned(), NotRemoteReferenceType()), true), 25) ::
                 (SubtypingError(ContractReferenceType(ContractType("AllPermissions", Nil), Unowned(), NotRemoteReferenceType()),
                     ContractReferenceType(ContractType("AllPermissions", Nil), Shared(), NotRemoteReferenceType()), true), 29) ::
-                (LostOwnershipErrorDueToSharing(ReferenceIdentifier("x2")), 41) ::
-                (LostOwnershipErrorDueToSharing(ReferenceIdentifier("x7")), 63) ::
+                (LostOwnershipErrorDueToSharing(ReferenceIdentifier("x2", Some(IntType()))), 41) ::
+                (LostOwnershipErrorDueToSharing(ReferenceIdentifier("x7", Some(IntType()))), 63) ::
                 (ReceiverTypeIncompatibleError("t1",
                     ContractReferenceType(ContractType("AllPermissions", Nil), Shared(), NotRemoteReferenceType()),
                     ContractReferenceType(ContractType("AllPermissions", Nil), Owned(), NotRemoteReferenceType())), 81) ::


### PR DESCRIPTION
this addresses #373. i added a field to the expression nodes of the AST to store their type as its computed so that it's then available to yul code generation. this meant making changes also to the parser and test cases, as well as a few other things, to reflect the different signatures for the relevant expressions.

right now this passes the typechecker tests; i am not at all confident that it's perfectly correct, but I think i need to use it to see what's broken and then fix those errors once they come up.

i have left comments where I was least sure about what I was doing. hopefully that will make the errors easier to find, or maybe some of them can get caught in review before they get merged.