### PR TITLE
use type annotations in Yul codegen

### DIFF
--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -251,9 +251,7 @@ object Main {
 
             val checker = new Checker(transformedTable, options.typeCheckerDebug)
             val (typecheckingErrors, checkedTable) = checker.checkProgram()
-
-            //assert(ParserUtil.symbolTableWithExpTypeProperty(checkedTable, (y: Option[Any]) => !y.isEmpty))
-
+            
             val allSortedErrors = (duplicateErrors ++ importErrors ++ transformErrors ++ typecheckingErrors).sorted
 
             if (!allSortedErrors.isEmpty) {

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -253,6 +253,12 @@ object Main {
             val checker = new Checker(transformedTable, options.typeCheckerDebug)
             val (typecheckingErrors, checkedTable) = checker.checkProgram()
 
+            // todo: after the above call, transformedTable.contractLookup.size = 3 on a program with two contracts
+            //  because a contract called Contract with nothing in it gets added. I think this is an error; it doesn't
+            //  appear in the program text and we have to special case to ignore it later in Yul generation. I don't
+            //  know what role it might play in other parts of the compiler. but this is where it first appears,
+            //  and therefore near where to remove it.
+            
             val allSortedErrors = (duplicateErrors ++ importErrors ++ transformErrors ++ typecheckingErrors).sorted
 
             if (!allSortedErrors.isEmpty) {

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -3,7 +3,6 @@ package edu.cmu.cs.obsidian
 import java.io.{File, FileInputStream}
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 import java.util.Scanner
-
 import org.apache.commons.io.FileUtils
 
 import scala.collection.mutable.HashSet
@@ -252,6 +251,8 @@ object Main {
 
             val checker = new Checker(transformedTable, options.typeCheckerDebug)
             val (typecheckingErrors, checkedTable) = checker.checkProgram()
+
+            //assert(ParserUtil.symbolTableWithExpTypeProperty(checkedTable, (y: Option[Any]) => !y.isEmpty))
 
             val allSortedErrors = (duplicateErrors ++ importErrors ++ transformErrors ++ typecheckingErrors).sorted
 

--- a/src/main/scala/edu/cmu/cs/obsidian/Main.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/Main.scala
@@ -253,12 +253,6 @@ object Main {
             val checker = new Checker(transformedTable, options.typeCheckerDebug)
             val (typecheckingErrors, checkedTable) = checker.checkProgram()
 
-            // todo: after the above call, transformedTable.contractLookup.size = 3 on a program with two contracts
-            //  because a contract called Contract with nothing in it gets added. I think this is an error; it doesn't
-            //  appear in the program text and we have to special case to ignore it later in Yul generation. I don't
-            //  know what role it might play in other parts of the compiler. but this is where it first appears,
-            //  and therefore near where to remove it.
-            
             val allSortedErrors = (duplicateErrors ++ importErrors ++ transformErrors ++ typecheckingErrors).sorted
 
             if (!allSortedErrors.isEmpty) {

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -504,28 +504,11 @@ object CodeGenYul extends CodeGenerator {
                 }
             case e@LocalInvocation(name, genericParams, params, args, obstype) => // todo: why are the middle two args not used?
                 // look up the name of the function in the table, get its return type, and then compute
-                // how wide of a tuple that return type is. (currently this is always either 0 or 1).
-                //
-                // todo: this is a hack. when we add type arguments to the translation, we'll be able to do this correctly.
-                val width = checkedTable.contractLookup(contractName).lookupTransaction(name) match {
-                    case Some(trans) =>
-                        trans.retType match {
-                            case Some(typ) => obsTypeToWidth(typ)
-                            case None => 0
-                        }
-                    case None =>
-                        // this is an absolute kludge just to get a proof of concept working for a specific test case
-                        if (name == transactionNameMapping("IntContainer", "set")) {
-                            0
-                        } else if (name == transactionNameMapping("IntContainer", "get")) {
-                            1
-                        } else if (name == transactionNameMapping("IntContainer", "set1")) {
-                            0
-                        } else if (name == transactionNameMapping("IntContainer", "set2")) {
-                            0
-                        } else {
-                            assert(false, s"width of transaction named ${name}")
-                        }
+                // how wide of a tuple that return type is. right now that's either 1 (if the
+                // transaction returns) or 0 (because it's void)
+                val width = obstype match {
+                    case Some(t) => obsTypeToWidth(t)
+                    case None => assert(false, s"width failed on transaction named ${name} from expression ${e.toString}")
                 }
 
                 // todo: some of this logic may be repeated in the dispatch table

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -87,7 +87,8 @@ object CodeGenYul extends CodeGenerator {
         var childContracts: Seq[YulObject] = Seq()
         // todo: this collection always contains a contract that looks like
         //   ObsidianContractImpl(Set(),Contract,List(),Contract,List(),None,true,)
-        //   and i do not know why
+        //   and i do not know why. it appears because of the code in IdentityAstTransfomer.scala,
+        //   transformProgram, roughly line 20.
         for (c <- program.contracts) {
             c match {
                 case obsContract: ObsidianContractImpl =>

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/ParserUtil.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/ParserUtil.scala
@@ -17,7 +17,7 @@ package object ParserUtil {
       * @param prop the property of interest
       * @return true if every type annotation in the expression has the property; false otherwise
       */
-    def expressionWithTypeProperty(e: edu.cmu.cs.obsidian.parser.Expression, prop: Option[ObsidianType] => Boolean): Boolean = {
+    def expressionHasTypeProperty(e: edu.cmu.cs.obsidian.parser.Expression, prop: Option[ObsidianType] => Boolean): Boolean = {
         e match {
             case expression: AtomicExpression => expression match {
                 case ReferenceIdentifier(name, typ) => prop(typ)
@@ -29,58 +29,58 @@ package object ParserUtil {
                 case Parent() => true
             }
             case expression: UnaryExpression => expression match {
-                case LogicalNegation(e) => expressionWithTypeProperty(e, prop)
-                case Negate(e) => expressionWithTypeProperty(e, prop)
-                case Dereference(e, _) => expressionWithTypeProperty(e, prop)
-                case Disown(e) => expressionWithTypeProperty(e, prop)
+                case LogicalNegation(e) => expressionHasTypeProperty(e, prop)
+                case Negate(e) => expressionHasTypeProperty(e, prop)
+                case Dereference(e, _) => expressionHasTypeProperty(e, prop)
+                case Disown(e) => expressionHasTypeProperty(e, prop)
             }
             case expression: BinaryExpression => prop(expression.obstype) &&
                 (expression match {
-                    case Conjunction(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Disjunction(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Add(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case StringConcat(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Subtract(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Divide(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Multiply(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Mod(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case parser.Equals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case GreaterThan(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case GreaterThanOrEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case LessThan(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case LessThanOrEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case NotEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Conjunction(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case Disjunction(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case Add(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case StringConcat(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case Subtract(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case Divide(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case Multiply(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case Mod(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case parser.Equals(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case GreaterThan(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case GreaterThanOrEquals(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case LessThan(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case LessThanOrEquals(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
+                    case NotEquals(e1, e2) => expressionHasTypeProperty(e1, prop) && expressionHasTypeProperty(e2, prop)
                 })
-            case LocalInvocation(name, genericParams, params, args, typ) => prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
-            case Invocation(recipient, genericParams, params, name, args, isFFIInvocation, typ) => expressionWithTypeProperty(recipient, prop) && prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
-            case Construction(contractType, args, isFFIInvocation, typ) => prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
+            case LocalInvocation(name, genericParams, params, args, typ) => prop(typ) && args.forall(ePrime => expressionHasTypeProperty(ePrime, prop))
+            case Invocation(recipient, genericParams, params, name, args, isFFIInvocation, typ) => expressionHasTypeProperty(recipient, prop) && prop(typ) && args.forall(ePrime => expressionHasTypeProperty(ePrime, prop))
+            case Construction(contractType, args, isFFIInvocation, typ) => prop(typ) && args.forall(ePrime => expressionHasTypeProperty(ePrime, prop))
             case StateInitializer(stateName, fieldName, typ) => prop(typ)
         }
     }
 
     def statementWithExpTypeProperty(s: Statement, prop: Option[ObsidianType] => Boolean): Boolean = {
         s match {
-            case e: Expression => expressionWithTypeProperty(e, prop)
+            case e: Expression => expressionHasTypeProperty(e, prop)
             case VariableDecl(typ, varName) => true
-            case VariableDeclWithInit(typ, varName, e) => expressionWithTypeProperty(e, prop)
+            case VariableDeclWithInit(typ, varName, e) => expressionHasTypeProperty(e, prop)
             case VariableDeclWithSpec(typIn, typOut, varName) => true
             case Return() => true
-            case ReturnExpr(e) => expressionWithTypeProperty(e, prop)
+            case ReturnExpr(e) => expressionHasTypeProperty(e, prop)
             case Transition(newStateName, updates, thisPermission) => updates match {
-                case Some(updates) => updates.forall(u => expressionWithTypeProperty(u._2, prop))
+                case Some(updates) => updates.forall(u => expressionHasTypeProperty(u._2, prop))
                 case None => true
             }
-            case Assignment(assignTo, e) => expressionWithTypeProperty(assignTo, prop) && expressionWithTypeProperty(e, prop)
+            case Assignment(assignTo, e) => expressionHasTypeProperty(assignTo, prop) && expressionHasTypeProperty(e, prop)
             case Revert(maybeExpr) => maybeExpr match {
-                case Some(e) => expressionWithTypeProperty(e, prop)
+                case Some(e) => expressionHasTypeProperty(e, prop)
                 case None => true
             }
-            case If(eCond, s) => expressionWithTypeProperty(eCond, prop) && s.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
-            case IfThenElse(eCond, s1, s2) => expressionWithTypeProperty(eCond, prop) && s1.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)) && s2.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
-            case IfInState(e, ePerm, typeState, s1, s2) => expressionWithTypeProperty(e, prop) && s1.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)) && s2.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
+            case If(eCond, s) => expressionHasTypeProperty(eCond, prop) && s.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
+            case IfThenElse(eCond, s1, s2) => expressionHasTypeProperty(eCond, prop) && s1.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)) && s2.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
+            case IfInState(e, ePerm, typeState, s1, s2) => expressionHasTypeProperty(e, prop) && s1.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)) && s2.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
             case TryCatch(s1, s2) => s1.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)) && s2.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop))
-            case Switch(e, cases) => expressionWithTypeProperty(e, prop) && cases.forall((sc: SwitchCase) => sc.body.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)))
-            case StaticAssert(e, typeState) => expressionWithTypeProperty(e, prop)
+            case Switch(e, cases) => expressionHasTypeProperty(e, prop) && cases.forall((sc: SwitchCase) => sc.body.forall((sPrime: Statement) => statementWithExpTypeProperty(sPrime, prop)))
+            case StaticAssert(e, typeState) => expressionHasTypeProperty(e, prop)
         }
     }
 
@@ -89,7 +89,7 @@ package object ParserUtil {
             case declaration: InvokableDeclaration => declaration match {
                 case Constructor(name, args, resultType, body) => body.forall((s: Statement) => statementWithExpTypeProperty(s, prop))
                 case Transaction(name, params, args, retType, ensures, body, isStatic, isPrivate, thisType, thisFinalType, initialFieldTypes, finalFieldTypes) =>
-                    body.forall((s: Statement) => statementWithExpTypeProperty(s, prop)) && ensures.forall((e: Ensures) => expressionWithTypeProperty(e.expr, prop))
+                    body.forall((s: Statement) => statementWithExpTypeProperty(s, prop)) && ensures.forall((e: Ensures) => expressionHasTypeProperty(e.expr, prop))
             }
             case TypeDecl(name, typ) => true
             case Field(isConst, typ, name, availableIn) => true

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/ParserUtil.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/ParserUtil.scala
@@ -1,0 +1,61 @@
+package edu.cmu.cs.obsidian
+
+import edu.cmu.cs.obsidian.typecheck.ObsidianType
+import edu.cmu.cs.obsidian.parser._
+
+package object ParserUtil {
+    /**
+      * traverse the structure of an expression and compute whether or not a given property holds
+      * on its type annotation. (nb: this is a map-reduce and there may be a slick scala OOP way to
+      * save actually writing it out by hand. it's also not clear to me that boolean is the best
+      * return type; option might be more informative, so that you can return information about the
+      * place where the property fails.)
+      *
+      * this is in its own file to avoid some nasty import conflicts
+      *
+      * @param e    the expression to traverse
+      * @param prop the property of interest
+      * @return true if every type annotation in the expression has the property; false otherwise
+      */
+    def expressionWithTypeProperty(e: edu.cmu.cs.obsidian.parser.Expression, prop: Option[ObsidianType] => Boolean): Boolean = {
+        e match {
+            case expression: AtomicExpression => expression match {
+                case ReferenceIdentifier(name, typ) => prop(typ)
+                case NumLiteral(_) => true
+                case parser.StringLiteral(_) => true
+                case TrueLiteral() => true
+                case FalseLiteral() => true
+                case This(typ) => prop(typ)
+                case Parent() => true
+            }
+            case expression: UnaryExpression => expression match {
+                case LogicalNegation(e) => expressionWithTypeProperty(e, prop)
+                case Negate(e) => expressionWithTypeProperty(e, prop)
+                case Dereference(e, _) => expressionWithTypeProperty(e, prop)
+                case Disown(e) => expressionWithTypeProperty(e, prop)
+            }
+            case expression: BinaryExpression => prop(expression.obstype) &&
+                (expression match {
+                    case Conjunction(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Disjunction(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Add(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case StringConcat(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Subtract(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Divide(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Multiply(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case Mod(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case parser.Equals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case GreaterThan(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case GreaterThanOrEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case LessThan(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case LessThanOrEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                    case NotEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
+                })
+            case LocalInvocation(name, genericParams, params, args, typ) => prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
+            case Invocation(recipient, genericParams, params, name, args, isFFIInvocation, typ) => expressionWithTypeProperty(recipient, prop) && prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
+            case Construction(contractType, args, isFFIInvocation, typ) => prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
+            case StateInitializer(stateName, fieldName, typ) => prop(typ)
+        }
+    }
+
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -1,8 +1,8 @@
 package edu.cmu.cs.obsidian.codegen
 
-import edu.cmu.cs.obsidian.parser._
-import edu.cmu.cs.obsidian.typecheck._
-import edu.cmu.cs.obsidian.{codegen, parser}
+
+import edu.cmu.cs.obsidian.codegen
+import edu.cmu.cs.obsidian.typecheck.{BoolType, BottomType, ContractReferenceType, GenericType, Int256Type, IntType, InterfaceContractType, NonPrimitiveType, ObsidianType, PrimitiveType, StateType, StringType, UnitType}
 import org.bouncycastle.jcajce.provider.digest.Keccak
 import org.bouncycastle.util.encoders.Hex
 
@@ -309,58 +309,6 @@ object Util {
             None
         } else {
             Some(halves(0), halves(1))
-        }
-    }
-
-    /**
-      * traverse the structure of an expression and compute whether or not a given property holds
-      * on its type annotation. (nb: this is a map-reduce and there may be a slick scala OOP way to
-      * save actually writing it out by hand. it's also not clear to me that boolean is the best
-      * return type; option might be more informative, so that you can return information about the
-      * place where the property fails.)
-      *
-      * @param e    the expression to traverse
-      * @param prop the property of interest
-      * @return true if every type annotation in the expression has the property; false otherwise
-      */
-    def expressionWithTypeProperty(e: edu.cmu.cs.obsidian.parser.Expression, prop: Option[ObsidianType] => Boolean): Boolean = {
-        e match {
-            case expression: AtomicExpression => expression match {
-                case ReferenceIdentifier(name, typ) => prop(typ)
-                case NumLiteral(_) => true
-                case parser.StringLiteral(_) => true
-                case TrueLiteral() => true
-                case FalseLiteral() => true
-                case This(typ) => prop(typ)
-                case Parent() => true
-            }
-            case expression: UnaryExpression => expression match {
-                case LogicalNegation(e) => expressionWithTypeProperty(e, prop)
-                case Negate(e) => expressionWithTypeProperty(e, prop)
-                case Dereference(e, _) => expressionWithTypeProperty(e, prop)
-                case Disown(e) => expressionWithTypeProperty(e, prop)
-            }
-            case expression: BinaryExpression => prop(expression.obstype) &&
-                (expression match {
-                    case Conjunction(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Disjunction(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Add(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case StringConcat(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Subtract(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Divide(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Multiply(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case Mod(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case parser.Equals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case GreaterThan(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case GreaterThanOrEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case LessThan(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case LessThanOrEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                    case NotEquals(e1, e2) => expressionWithTypeProperty(e1, prop) && expressionWithTypeProperty(e2, prop)
-                })
-            case LocalInvocation(name, genericParams, params, args, typ) => prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
-            case Invocation(recipient, genericParams, params, name, args, isFFIInvocation, typ) => expressionWithTypeProperty(recipient, prop) && prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
-            case Construction(contractType, args, isFFIInvocation, typ) => prop(typ) && args.forall(ePrime => expressionWithTypeProperty(ePrime, prop))
-            case StateInitializer(stateName, fieldName, typ) => prop(typ)
         }
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -207,10 +207,6 @@ object Util {
         1
     }
 
-    def functionRename(name: String): String = {
-        name //todo some sort of alpha variation here combined with consulting a mapping; consult the ABI
-    }
-
     def keccak256(s: String): String = {
         val digestK: Keccak.Digest256 = new Keccak.Digest256()
         s"0x${Hex.toHexString(digestK.digest(s.getBytes).slice(0, 4))}"

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -2,7 +2,7 @@ package edu.cmu.cs.obsidian.codegen
 
 
 import edu.cmu.cs.obsidian.codegen
-import edu.cmu.cs.obsidian.typecheck.{BoolType, BottomType, ContractReferenceType, GenericType, Int256Type, IntType, InterfaceContractType, NonPrimitiveType, ObsidianType, PrimitiveType, StateType, StringType, UnitType}
+import edu.cmu.cs.obsidian.typecheck._
 import org.bouncycastle.jcajce.provider.digest.Keccak
 import org.bouncycastle.util.encoders.Hex
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -207,7 +207,17 @@ object Util {
     def obsTypeToWidth(t: ObsidianType): Int = {
         // this only gets called in one place, which is the translation of local invocations.
         // it should either be 1 or 0, indicating if the return type is void (0) or not (1)
-        1
+        t match {
+            case primitiveType: PrimitiveType => primitiveType match {
+                case IntType() => 1
+                case BoolType() => 1
+                case StringType() => 1
+                case Int256Type() => 1
+                case UnitType() => 0
+            }
+            case primitiveType: NonPrimitiveType => assert(false, "width not implemented for nonprimitive types!"); -1
+            case BottomType() => assert(false, "width not implemented for the bottom type!"); -1
+        }
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -204,6 +204,8 @@ object Util {
       * @return the width of the type
       */
     def obsTypeToWidth(t: ObsidianType): Int = {
+        // this only gets called in one place, which is the translation of local invocations.
+        // it should either be 1 or 0, indicating if the return type is void (0) or not (1)
         1
     }
 
@@ -265,7 +267,7 @@ object Util {
       * @param e the expression of interest
       * @return the name of the contract for the expression, if there is one; raises an error otherwise
       */
-    def getContractName(e: edu.cmu.cs.obsidian.parser.Expression): String = {
+    def getContractName(e: edu.cmu.cs.obsidian.parser.Expression): String = { //todo should this return an option? what's the invariant exactly?
         e.obstype match {
             case Some(value) => value match {
                 case _: PrimitiveType => assert(false, s"primitive types do not have contract names"); ""

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -274,7 +274,7 @@ case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], ch
 
             //todo: second argument to the application is highly speculative; check once you have more complex functions
             // the actual call to f, and a possible declaration of the temporary variables if there are any returns
-            val call_to_f: Expression = apply(functionRename(f.name), f.parameters.map(p => Identifier(p.name)): _*)
+            val call_to_f: Expression = apply(f.name, f.parameters.map(p => Identifier(p.name)): _*)
             val call_f_and_maybe_assign: YulStatement =
                 if (f.returnVariables.nonEmpty) {
                     codegen.VariableDeclaration(temps.map(i => (i, None)), Some(call_to_f))

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1,5 +1,6 @@
 package edu.cmu.cs.obsidian.typecheck
 
+import edu.cmu.cs.obsidian.ParserUtil
 import edu.cmu.cs.obsidian.parser._
 
 import scala.collection.immutable.TreeMap
@@ -1859,6 +1860,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 }
                 val (contextPrime, statementPrime, ePrime) = checkAssignment(x, e, context, false)
                 //(contextPrime, Assignment(ReferenceIdentifier(x, ePrime.obstype), ePrime).setLoc(s)) // todo iev
+                assert(ParserUtil.expressionWithTypeProperty(ePrime, (y: Option[ObsidianType]) => !y.isEmpty))
                 (contextPrime, Assignment(ReferenceIdentifier(x, obstyp), ePrime).setLoc(s))
 
             case Assignment(Dereference(eDeref, f), e: Expression) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -871,7 +871,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
             case LocalInvocation(name, _, params, args: Seq[Expression], obstype) =>
                 //todo should there be an assertion to check that obstype == typ? which one takes precedence?
-                //todo i don't konw if passing `obstype` to This is correct at all
+                //todo i don't know if passing `obstype` to This is correct at all
                 val (typ, con, _, _, newGenericParams, newArgs) = handleInvocation(context, name, This(obstype).setLoc(e), params, args)
                 //This may need correction.
                 (typ, con, LocalInvocation(name, newGenericParams, params, newArgs, Some(typ)).setLoc(e))

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1864,7 +1864,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     logError(s, InvalidValAssignmentError())
                 }
                 val (contextPrime, statementPrime, ePrime) = checkAssignment(x, e, context, false)
-                assert(ParserUtil.expressionWithTypeProperty(ePrime, (y: Option[ObsidianType]) => !y.isEmpty))
+                assert(ParserUtil.expressionHasTypeProperty(ePrime, (y: Option[ObsidianType]) => !y.isEmpty))
                 (contextPrime, Assignment(ReferenceIdentifier(x, obstyp), ePrime).setLoc(s))
 
             case Assignment(Dereference(eDeref, f), e: Expression) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1864,13 +1864,11 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     logError(s, InvalidValAssignmentError())
                 }
                 val (contextPrime, statementPrime, ePrime) = checkAssignment(x, e, context, false)
-                //(contextPrime, Assignment(ReferenceIdentifier(x, ePrime.obstype), ePrime).setLoc(s)) // todo iev
                 assert(ParserUtil.expressionWithTypeProperty(ePrime, (y: Option[ObsidianType]) => !y.isEmpty))
                 (contextPrime, Assignment(ReferenceIdentifier(x, obstyp), ePrime).setLoc(s))
 
             case Assignment(Dereference(eDeref, f), e: Expression) =>
-                assert(false, "the code below this case is certainly wrong and will need to be debugged on an example")
-                if (eDeref != This(None)) { //todo: this is totally wrong again, i seem not to know how to get the type for `this`
+                if (eDeref != This(None)) { //todo: this is totally wrong again, i seem not to know how to get the type for `this`. maybe this needs to be a match not an if so i can check if it's This(_)?
                     logError(s, InvalidNonThisFieldAssignment())
                     (context, s)
                 }

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -727,7 +727,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     else {
                         context
                     }
-                (thisType, newContext, e)
+                (thisType, newContext, ParserUtil.updateExprType(e,thisType))
             case Parent() =>
                 assert(false, "TODO: re-add support for parents")
                 /*
@@ -846,14 +846,15 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                             case Some(t) =>
                                 val newType = t.residualType(ownershipConsumptionMode)
                                 if (newType != t) {
-                                    (t, context.updatedThisFieldType(fieldName, newType), e)
+                                    (t, context.updatedThisFieldType(fieldName, newType), ParserUtil.updateExprType(e,t))
                                 }
                                 else {
-                                    (t, context, e)
+                                    (t, context, ParserUtil.updateExprType(e,t))
                                 }
                             case None =>
                                 logError(e, FieldUndefinedError(context.thisType, fieldName))
-                                (BottomType(), context, e)
+                                val t = BottomType()
+                                (t, context, ParserUtil.updateExprType(e,t))
                         }
 
                     case _ =>
@@ -868,7 +869,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                                     }
                                     (ePrime, c)
                             }
-                        (BottomType(), newContext, newExpr)
+                        val t = BottomType()
+                        (t, newContext, ParserUtil.updateExprType(newExpr,t))
                 }
 
             case LocalInvocation(name, _, params, args: Seq[Expression], obstype) =>
@@ -895,7 +897,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
 
                 if (tableLookup.isEmpty) {
                     logError(e, ContractUndefinedError(contractType.contractName))
-                    return (BottomType(), context, e)
+                    val t = BottomType()
+                    return (t, context, ParserUtil.updateExprType(e,t))
                 }
 
                 if (tableLookup.get.contract.isInterface) {
@@ -957,7 +960,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         }
                     case _ => contextPrime
                 }
-                (newTyp, finalContext, ePrime)
+                (newTyp, finalContext, ParserUtil.updateExprType(ePrime, newTyp))
             case StateInitializer(stateName, fieldName, obstype) =>
                 // A state initializer expression has its field's type.
                 if (!context.transitionFieldsDefinitelyInitialized.exists(
@@ -979,7 +982,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 }
 
                 //assert(! e.obstype.isEmpty, s"infer and check failed to populate the type of ${e.toString}")
-                (fieldType, context, e)
+                (fieldType, context, ParserUtil.updateExprType(e, fieldType))
         }
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -1858,6 +1858,7 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                     logError(s, InvalidValAssignmentError())
                 }
                 val (contextPrime, statementPrime, ePrime) = checkAssignment(x, e, context, false)
+                //(contextPrime, Assignment(ReferenceIdentifier(x, ePrime.obstype), ePrime).setLoc(s)) // todo iev
                 (contextPrime, Assignment(ReferenceIdentifier(x, obstyp), ePrime).setLoc(s))
 
             case Assignment(Dereference(eDeref, f), e: Expression) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -686,29 +686,31 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                         // But consuming in a context that expects sharing results in Shared.
                         val newType = t.residualType(ownershipConsumptionMode)
                         if (newType != t) {
-                            (t, context.updated(x, newType), e)
+                            (t, context.updated(x, newType), ParserUtil.updateExprType(e, t))
                         }
                         else {
-                            (t, context, e)
+                            (t, context, ParserUtil.updateExprType(e, t))
                         }
                     case (_, Some(t)) =>
                         val newType = t.residualType(ownershipConsumptionMode)
                         if (newType != t) {
-                            (t, context.updatedThisFieldType(x, newType), e)
+                            (t, context.updatedThisFieldType(x, newType), ParserUtil.updateExprType(e, t))
                         }
                         else {
-                            (t, context, e)
+                            (t, context, ParserUtil.updateExprType(e, t))
                         }
                     case (None, None) =>
                         val tableLookup = context.contractTable.lookupContract(x)
                         if (tableLookup.isDefined) {
                             val contractTable = tableLookup.get
                             val nonPrimitiveType = ContractReferenceType(contractTable.contractType, Shared(), NotRemoteReferenceType())
-                            (InterfaceContractType(contractTable.name, nonPrimitiveType), context, e)
+                            val t = InterfaceContractType(contractTable.name, nonPrimitiveType)
+                            (t, context, ParserUtil.updateExprType(e, t))
                         }
                         else {
                             logError(e, VariableUndefinedError(x, context.thisType.toString))
-                            (BottomType(), context, e)
+                            val t = BottomType()
+                            (t, context, ParserUtil.updateExprType(e, t))
                         }
                 }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/util/IdentityAstTransformer.scala
@@ -17,6 +17,10 @@ class IdentityAstTransformer {
 
     def transformProgram(table: SymbolTable): (SymbolTable, Seq[ErrorRecord]) = {
         var errorRecords = List.empty[ErrorRecord]
+
+        // todo: this line is exactly where the empty contract "Contract" comes from. if i change
+        //   it to start with an empty list instead of adding a contract always, many tests fail.
+        //   i don't really understand why. this is probably correct but i want to know more about it.
         var contracts = List[Contract](ContractType.topContractImpl)
         assert(table.ast.imports.isEmpty, "Imports should be empty after processing.")
 


### PR DESCRIPTION
This addresses #373! We use the type annotations in the expression ASTs to smooth out the translations and remove a fair few hacks.

There are a couple of loose ends:

1. The `This` AST node constructor now takes a type argument. There are two places in `Checker.scala` that I don't know what to put there other than `None` because there aren't any obsidian types in the (scala) context at that time. @mcoblenz, do you know? I've noted them in the review below; there's another one on `Checker.scala:2705` that I think is more benign because that's already kind of a hack so it makes sense that it doesn't make sense.
2. This PR passes all the GanacheTests and almost all of the tests in the larger test suite, but not all the typechecker tests (shown below). So I must have broken something. The tests that are failing are in parts of the typechecker I don't know that well; again, @mcoblenz, do you know how to fix these or where I'd start to look? This should get fixed before merging this PR, I think. (Note: these don't show up in the Travis builds because this PR isn't into master so it's only doing the Ganache matrix job. But you can recreate them locally from this branch with `sbt assembly` or `sbt test`.)

```
[info] TypeCheckerTests:
[info] - genericsTransactionParams
[info] - typeSpecificationTest
[info] - stateTest
[info] - transitionTest
[info] - endsInStateTest
[info] - multistateFieldsTest
[info] - stateInitializationTest
[info] - fieldOwnership
[info] - dereferenceTest
[info] - basicTest
[info] - bottomTest
[info] - sameFieldNameTest
[info] - inStateOwnershipChange
[info] - argShadowingTest
[info] - assetStateTrackingOwnedOkay
[info] - constructorFieldTypes
[info] - uninitializedFieldTest
[info] - interfaceDoesntRequireReturnTest
[info] - revertTest
[info] - multipleConstructorDistinguishableTest
[info] - constructorPermissionRequiredMissing
[info] - comparisonTest
[info] - sideEffectTest *** FAILED ***
[info]   java.lang.AssertionError: Unexpected error: NoEffectsError(x) at line 8
[info]   at org.junit.Assert.fail(Assert.java:88)
[info]   at org.junit.Assert.assertTrue(Assert.java:41)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.$anonfun$runTest$2(TypeCheckerTests.scala:47)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
[info]   at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:889)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.runTest(TypeCheckerTests.scala:40)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.sideEffectTest(TypeCheckerTests.scala:325)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   ...
[info] - equalityTest *** FAILED ***
[info]   java.lang.AssertionError: Unexpected error: DifferentTypeError(a,int,b,string) at line 12
[info]   at org.junit.Assert.fail(Assert.java:88)
[info]   at org.junit.Assert.assertTrue(Assert.java:41)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.$anonfun$runTest$2(TypeCheckerTests.scala:47)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
[info]   at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:889)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.runTest(TypeCheckerTests.scala:40)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.equalityTest(TypeCheckerTests.scala:197)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   ...
[info] - variableTest
[info] - genericsInterfaceImplementsBound
[info] - assetStateTrackingOwned
[info] - permissionPassing *** FAILED ***
[info]   java.lang.AssertionError: Unexpected error: UnusedExpressionArgumentOwnershipError(returnOwnedAsset()) at line 58
[info]   at org.junit.Assert.fail(Assert.java:88)
[info]   at org.junit.Assert.assertTrue(Assert.java:41)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.$anonfun$runTest$2(TypeCheckerTests.scala:47)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
[info]   at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:889)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.runTest(TypeCheckerTests.scala:40)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.permissionPassing(TypeCheckerTests.scala:909)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   ...
[info] - duplicateNames
[info] - transactionParamShadowTest
[info] - vals
[info] - genericsAssets
[info] - inStateTest
[info] - operationTest
[info] - typeInferenceTest
[info] - privateTransactionsTest
[info] - noStartStateTest
[info] - allPermissions *** FAILED ***
[info]   java.lang.AssertionError: Unexpected error: LostOwnershipErrorDueToSharing(x2) at line 41
[info]   at org.junit.Assert.fail(Assert.java:88)
[info]   at org.junit.Assert.assertTrue(Assert.java:41)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.$anonfun$runTest$2(TypeCheckerTests.scala:47)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
[info]   at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:889)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.runTest(TypeCheckerTests.scala:40)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.allPermissions(TypeCheckerTests.scala:919)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   ...
[info] - endsInStateUnionTest
[info] - branchingTest
[info] - assignmentTest
[info] - unownedReferenceTest
[info] - staticAssertsTest
[info] - fieldsTest
[info] - shadowingTest
[info] - multipleConstructorAmbiguousTest
[info] - multipleConstructorsTest
[info] - noMainContractTest
[info] - variableDeclarationsTest
[info] - duplicateContractDecl
[info] - resourcesTest *** FAILED ***
[info]   java.lang.AssertionError: Unexpected error: DisownUnowningExpressionError(m) at line 49
[info]   at org.junit.Assert.fail(Assert.java:88)
[info]   at org.junit.Assert.assertTrue(Assert.java:41)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.$anonfun$runTest$2(TypeCheckerTests.scala:47)
[info]   at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
[info]   at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
[info]   at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
[info]   at scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:889)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.runTest(TypeCheckerTests.scala:40)
[info]   at edu.cmu.cs.obsidian.tests.TypeCheckerTests.resourcesTest(TypeCheckerTests.scala:455)
[info]   at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info]   ...
[info] - droppedAssetsTest
[info] - ownershipTest
[info] - fieldTypeMismatchTest
[info] - returnTest
[info] - okayBasicGenerics
[info] - genericsOwnership
[info] - genericsLinkedList
[info] - readOnlyStateTest
[info] - contractUndefinedTest
[info] - genericsInterfaceWithParameters
[info] - genericsInterfaceBasicSwitch
[info] - invocationTest
[info] - constructorPermissionRequired
[info] - stringConcatenation
[info] - genericsMismatchIntString
[info] - genericsStateVariables
```