### PR TITLE
fixing checkAndInfer for negation

### DIFF
--- a/resources/tests/GanacheTests/PrimOpsNeg.json
+++ b/resources/tests/GanacheTests/PrimOpsNeg.json
@@ -1,0 +1,8 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1,
+    "testexp" : "primopsneg()",
+    "expected" : "-20"
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/typecheck/Checker.scala
@@ -818,7 +818,8 @@ class Checker(globalTable: SymbolTable, verbose: Boolean = false) {
                 val (typ, con, e1Prime, e2Prime) = assertOperationType(e1, e2, IntType())
                 (typ, con, Mod(e1Prime, e2Prime).setLoc(e))
             case Negate(e: Expression) =>
-                assertTypeEquality(e, IntType(), context)
+                val (typ, con, eprime) = assertTypeEquality(e, IntType(), context)
+                (typ, con, Negate(eprime).setLoc(e))
             case Equals(e1: Expression, e2: Expression) =>
                 val (t1, c1, e1Prime) = inferAndCheckExpr(decl, context, e1, NoOwnershipConsumption())
                 val (t2, c2, e2Prime) = inferAndCheckExpr(decl, c1, e2, NoOwnershipConsumption())


### PR DESCRIPTION
The negation expression of check and infer dropped the negation around the expression before returning it, which caused the test to fail in https://github.com/mcoblenz/Obsidian/issues/337. This PR fixes that. The issue originally identified this as a parser issue, but with some digging in the debugger, I saw that it came out of the parser fine but the AST was getting mangled while being type checked.