### PR TITLE
compute offsets, store fields in memory

### DIFF
--- a/bin/skipped_tests.sh
+++ b/bin/skipped_tests.sh
@@ -3,4 +3,4 @@
 # when run from the top level of the repo, this prints out the names of the obsidian files
 # in the ganache tests that do not also have a json file paired with them -- that means that
 # they won't be run by travis. this also appears in the output of the travis script at the very top.
-comm -13 <(ls resources/tests/GanacheTests/*.json | xargs basename -s '.json') <(ls resources/tests/GanacheTests/*.obs | xargs basename -s '.obs')
+comm -13 <(ls resources/tests/GanacheTests/*.json | xargs basename -s '.json' | sort) <(ls resources/tests/GanacheTests/*.obs | xargs basename -s '.obs' | sort)

--- a/resources/tests/GanacheTests/SG.json
+++ b/resources/tests/GanacheTests/SG.json
@@ -1,0 +1,8 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1,
+    "testexp" : "main()",
+    "expected" : "1800"
+}

--- a/resources/tests/GanacheTests/SG.obs
+++ b/resources/tests/GanacheTests/SG.obs
@@ -6,10 +6,13 @@ contract IntContainer{
 
     transaction set() {
         x = 5;
+	y = 10;
+	z = 4;
+	f = 9;
     }
 
     transaction get() returns int{
-        return x;
+        return x*y*z*f; // 1800
     }
 }
 

--- a/resources/tests/GanacheTests/SG.obs
+++ b/resources/tests/GanacheTests/SG.obs
@@ -1,6 +1,8 @@
 contract IntContainer{
     int x;
     int y;
+    int z;
+    int f;
 
     transaction set() {
         x = 5;

--- a/resources/tests/GanacheTests/SG.obs
+++ b/resources/tests/GanacheTests/SG.obs
@@ -1,0 +1,20 @@
+contract IntContainer{
+    int x;
+    int y;
+
+    transaction set() {
+        x = 5;
+    }
+
+    transaction get() returns int{
+        return x;
+    }
+}
+
+main contract SG{
+    transaction main() returns int{
+        IntContainer ic = new IntContainer();
+        ic.set();
+        return ic.get();
+    }
+}

--- a/resources/tests/GanacheTests/SG.obs
+++ b/resources/tests/GanacheTests/SG.obs
@@ -5,14 +5,14 @@ contract IntContainer{
     int f;
 
     transaction set() {
-	x = -1;
-	f = -1;
-	z = -1;
-	y = -1;
+        x = -1;
+        f = -1;
+        z = -1;
+        y = -1;
         x = 5;
-	y = 10;
-	z = 4;
-	f = 9;
+        y = 10;
+        z = 4;
+        f = 9;
     }
 
     transaction get() returns int{

--- a/resources/tests/GanacheTests/SG.obs
+++ b/resources/tests/GanacheTests/SG.obs
@@ -5,6 +5,10 @@ contract IntContainer{
     int f;
 
     transaction set() {
+	x = -1;
+	f = -1;
+	z = -1;
+	y = -1;
         x = 5;
 	y = 10;
 	z = 4;

--- a/resources/tests/GanacheTests/SGTwoContainers.json
+++ b/resources/tests/GanacheTests/SGTwoContainers.json
@@ -1,0 +1,8 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1,
+    "testexp" : "main()",
+    "expected" : "3600"
+}

--- a/resources/tests/GanacheTests/SGTwoContainers.obs
+++ b/resources/tests/GanacheTests/SGTwoContainers.obs
@@ -1,0 +1,31 @@
+contract IntContainer{
+    int x;
+    int y;
+    int z;
+    int f;
+
+    transaction set() {
+	x = -1;
+	f = -1;
+	z = -1;
+	y = -1;
+        x = 5;
+	y = 10;
+	z = 4;
+	f = 9;
+    }
+
+    transaction get() returns int{
+        return x*y*z*f; // 1800
+    }
+}
+
+main contract SGTwoContainers{
+    transaction main() returns int{
+        IntContainer ic1 = new IntContainer();
+        ic1.set();
+	IntContainer ic2 = new IntContainer();
+	ic2.set();
+        return ic1.get()+ic2.get();
+    }
+}

--- a/resources/tests/GanacheTests/SetGetNoArgs.obs
+++ b/resources/tests/GanacheTests/SetGetNoArgs.obs
@@ -1,7 +1,7 @@
 contract IntContainer{
     int x;
 
-    IntContainer@Owned() {
+    IntContainer() {
         x = 0;
     }
 

--- a/resources/tests/GanacheTests/SetGetNoArgsNoConstruct.obs
+++ b/resources/tests/GanacheTests/SetGetNoArgsNoConstruct.obs
@@ -6,7 +6,7 @@ contract IntContainer{
     }
 
     transaction set2() {
-            x = 10;
+        x = 10;
     }
 
     transaction get() returns int{
@@ -18,7 +18,7 @@ main contract SetGetNoArgsNoConstruct{
     transaction main() returns int{
         IntContainer ic = new IntContainer();
         ic.set1();
-            ic.set2();
+        ic.set2();
         return (ic.get());
     }
 }

--- a/resources/tests/GanacheTests/SetGetNoArgsNoConstruct.obs
+++ b/resources/tests/GanacheTests/SetGetNoArgsNoConstruct.obs
@@ -6,7 +6,7 @@ contract IntContainer{
     }
 
     transaction set2() {
-	    x = 10;
+            x = 10;
     }
 
     transaction get() returns int{
@@ -18,7 +18,7 @@ main contract SetGetNoArgsNoConstruct{
     transaction main() returns int{
         IntContainer ic = new IntContainer();
         ic.set1();
-	    ic.set2();
+            ic.set2();
         return (ic.get());
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -1,6 +1,7 @@
 package edu.cmu.cs.obsidian.codegen
 
 import edu.cmu.cs.obsidian.CompilerOptions
+import edu.cmu.cs.obsidian.typecheck.StringType
 
 import java.io.{File, FileWriter}
 import java.nio.file.{Files, Path, Paths}
@@ -236,7 +237,7 @@ object CodeGenYul extends CodeGenerator {
         Seq(ExpressionStatement(deployExpr),
             FunctionDefinition(
                 new_name, // TODO rename transaction name (by adding prefix/suffix) iev: this seems to be done already
-                constructor.args.map(v => TypedName(v.varName, baseTypeToYulName(v.typIn))),
+                constructor.args.map(v => TypedName(v.varName, v.typIn)),
                 Seq(), //todo/iev: why is this always empty?
                 Block(constructor.body.flatMap((s: Statement) => translateStatement(s, None, contractName, checkedTable, inMain = true))))) //todo iev flatmap may be a bug to hide something wrong; None means that constructors don't return. is that true?
     }
@@ -257,7 +258,7 @@ object CodeGenYul extends CodeGenerator {
             transaction.retType match {
                 case Some(t) =>
                     id = Some(nextRet())
-                    Seq(TypedName(id.get.name, baseTypeToYulName(t)))
+                    Seq(TypedName(id.get.name, t))
                 case None => Seq()
             }
         }
@@ -267,8 +268,8 @@ object CodeGenYul extends CodeGenerator {
             if (inMain) {
                 Seq() // add nothing
             } else {
-                Seq(TypedName("this", "string")) // todo "this" is emphatically not a string but i'm not sure what the type of it ought to be; addr?
-            } ++ transaction.args.map(v => TypedName(v.varName, baseTypeToYulName(v.typIn)))
+                Seq(TypedName("this", StringType())) // todo "this" is emphatically not a string but i'm not sure what the type of it ought to be; addr?
+            } ++ transaction.args.map(v => TypedName(v.varName, v.typIn))
 
         // form the body of the transaction by translating each statement found
         val body: Seq[YulStatement] = transaction.body.flatMap((s: Statement) => translateStatement(s, id, contractName, checkedTable, inMain))

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -117,7 +117,7 @@ object CodeGenYul extends CodeGenerator {
       * todo: right now we do not actually have enough type information to do the above in a robust way, but we will
       * add that soon
       *
-      * @param contract the contract to be translated
+      * @param contract     the contract to be translated
       * @param checkedTable the symbol table for that contract
       * @return the yul
       */
@@ -148,7 +148,7 @@ object CodeGenYul extends CodeGenerator {
       * ready to be inserted into the translation of a main yul object. this will rename the transactions according to the
       * contract name.
       *
-      * @param c the contract to be translated
+      * @param c            the contract to be translated
       * @param checkedTable the symbol table of the contract
       * @return the YulObject representing the translation. note that all the fields other than `code` will be the empty sequence.
       */
@@ -535,7 +535,7 @@ object CodeGenYul extends CodeGenerator {
                 // todo: this does not work with non-void functions that are called without binding
                 //  their results, ie "f()" if f returns an int
                 ids.map(id => decl_0exp(id)) ++
-                seqs.flatten ++ (width match {
+                    seqs.flatten ++ (width match {
                     case 0 => Seq(ExpressionStatement(FunctionCall(Identifier(name), ids)))
                     case 1 =>
                         val id: Identifier = nextTemp()
@@ -571,12 +571,18 @@ object CodeGenYul extends CodeGenerator {
                 // todo: currently we ignore the arguments to the constructor
                 assert(args.isEmpty, "contracts that take arguments are not yet supported")
 
-                val ct: Option[ContractTable] = checkedTable.contract(contractType.contractName)
+                // compute the amount of space we need to store something of this type, or assert
+                //   if that amount can't be computed.
+                val size: Int = checkedTable.contract(contractType.contractName) match {
+                    case Some(value) => sizeOfContract(value)
+                    case None => assert(false, s"contract table didn't contain contract name: ${contractType.contractName}")
+                }
 
                 val id_memaddr = nextTemp()
+
                 Seq(
                     // grab the appropriate amount of space of memory sequentially, off the free memory pointer
-                    decl_1exp(id_memaddr, apply("allocate_memory", intlit(sizeOfContract(ct.get)))),
+                    decl_1exp(id_memaddr, apply("allocate_memory", intlit(size))),
 
                     // return the address that the space starts at
                     assign1(retvar, id_memaddr)

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -311,7 +311,7 @@ object CodeGenYul extends CodeGenerator {
                             e_yul :+
                             (if (checkedTable.contractLookup(contractName).allFields.exists(f => f.name.equals(x))) {
                                 //todo: compute offsets
-                                ExpressionStatement(apply("sstore", hexlit(keccak256(contractName + x)), id))
+                                ExpressionStatement(apply("sstore", hexlit(keccak256(contractName + x)), id)) //here
                             } else {
                                 assign1(Identifier(x), id)
                             })
@@ -452,7 +452,7 @@ object CodeGenYul extends CodeGenerator {
                         if (checkedTable.contractLookup(contractName).allFields.exists(f => f.name.equals(x))) {
                             val store_id = nextTemp()
                             //todo: compute offsets
-                            Seq(decl_1exp(store_id, apply("sload", hexlit(keccak256(contractName + x)))),
+                            Seq(decl_1exp(store_id, apply("sload", hexlit(keccak256(contractName + x)))), //here
                                 assign1(retvar, store_id))
                         } else {
                             Seq(assign1(retvar, Identifier(x)))

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -312,7 +312,7 @@ object CodeGenYul extends CodeGenerator {
                             e_yul :+
                             (if (ct.allFields.exists(f => f.name.equals(x))) {
                                 //todo working here
-                                ExpressionStatement(apply("mstore", Util.fieldFromThis(ct,x), id))
+                                ExpressionStatement(apply("mstore", Util.fieldFromThis(ct, x), id))
                             } else {
                                 assign1(Identifier(x), id)
                             })
@@ -454,7 +454,7 @@ object CodeGenYul extends CodeGenerator {
                         if (ct.allFields.exists(f => f.name.equals(x))) {
                             val store_id = nextTemp()
                             //todo working here
-                            Seq(decl_1exp(store_id, apply("mload", Util.fieldFromThis(ct,x))),
+                            Seq(decl_1exp(store_id, apply("mload", Util.fieldFromThis(ct, x))),
                                 assign1(retvar, store_id))
                         } else {
                             Seq(assign1(retvar, Identifier(x)))

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -575,7 +575,7 @@ object CodeGenYul extends CodeGenerator {
                 //   if that amount can't be computed.
                 val size: Int = checkedTable.contract(contractType.contractName) match {
                     case Some(value) => sizeOfContract(value)
-                    case None => assert(false, s"contract table didn't contain contract name: ${contractType.contractName}")
+                    case None => assert(false, s"contract table didn't contain contract name: ${contractType.contractName}"); -1
                 }
 
                 val id_memaddr = nextTemp()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -236,7 +236,7 @@ object CodeGenYul extends CodeGenerator {
         Seq(ExpressionStatement(deployExpr),
             FunctionDefinition(
                 new_name, // TODO rename transaction name (by adding prefix/suffix) iev: this seems to be done already
-                constructor.args.map(v => TypedName(v.varName, obsTypeToYulTypeAndSize(v.typIn.toString)._1)),
+                constructor.args.map(v => TypedName(v.varName, baseTypeToYulName(v.typIn))),
                 Seq(), //todo/iev: why is this always empty?
                 Block(constructor.body.flatMap((s: Statement) => translateStatement(s, None, contractName, checkedTable, inMain = true))))) //todo iev flatmap may be a bug to hide something wrong; None means that constructors don't return. is that true?
     }
@@ -257,7 +257,7 @@ object CodeGenYul extends CodeGenerator {
             transaction.retType match {
                 case Some(t) =>
                     id = Some(nextRet())
-                    Seq(TypedName(id.get.name, obsTypeToYulTypeAndSize(t.toString)._1))
+                    Seq(TypedName(id.get.name, baseTypeToYulName(t)))
                 case None => Seq()
             }
         }
@@ -268,7 +268,7 @@ object CodeGenYul extends CodeGenerator {
                 Seq() // add nothing
             } else {
                 Seq(TypedName("this", "string")) // todo "this" is emphatically not a string but i'm not sure what the type of it ought to be; addr?
-            } ++ transaction.args.map(v => TypedName(v.varName, obsTypeToYulTypeAndSize(v.typIn.toString)._1))
+            } ++ transaction.args.map(v => TypedName(v.varName, baseTypeToYulName(v.typIn)))
 
         // form the body of the transaction by translating each statement found
         val body: Seq[YulStatement] = transaction.body.flatMap((s: Statement) => translateStatement(s, id, contractName, checkedTable, inMain))

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -307,11 +307,12 @@ object CodeGenYul extends CodeGenerator {
                         //  it also likely does not work correctly with shadowing.
                         val id = nextTemp()
                         val e_yul = translateExpr(id, e, contractName, checkedTable, inMain)
+                        val ct = checkedTable.contractLookup(contractName)
                         decl_0exp(id) +:
                             e_yul :+
-                            (if (checkedTable.contractLookup(contractName).allFields.exists(f => f.name.equals(x))) {
-                                //todo: compute offsets
-                                ExpressionStatement(apply("sstore", hexlit(keccak256(contractName + x)), id)) //here
+                            (if (ct.allFields.exists(f => f.name.equals(x))) {
+                                //todo working here
+                                ExpressionStatement(apply("mstore", Util.fieldFromThis(ct,x), id))
                             } else {
                                 assign1(Identifier(x), id)
                             })
@@ -449,10 +450,11 @@ object CodeGenYul extends CodeGenerator {
 
                         // todo: this also assumes that everything is a u256 and does no type-directed
                         //  cleaning in the way that solc does
-                        if (checkedTable.contractLookup(contractName).allFields.exists(f => f.name.equals(x))) {
+                        val ct = checkedTable.contractLookup(contractName)
+                        if (ct.allFields.exists(f => f.name.equals(x))) {
                             val store_id = nextTemp()
-                            //todo: compute offsets
-                            Seq(decl_1exp(store_id, apply("sload", hexlit(keccak256(contractName + x)))), //here
+                            //todo working here
+                            Seq(decl_1exp(store_id, apply("mload", Util.fieldFromThis(ct,x))),
                                 assign1(retvar, store_id))
                         } else {
                             Seq(assign1(retvar, Identifier(x)))

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -188,7 +188,7 @@ object Util {
                 case Int256Type() => "int256"
                 case UnitType() => assert(assertion = false, "unimplemented: unit type not encoded in Yul"); ""
             }
-            case _: NonPrimitiveType => assert(assertion = false, s"${typ.toString} is not primitive"); ""
+            case t: NonPrimitiveType => t.contractName 
             case BottomType() => assert(assertion = false, "unimplemented: bottom type not encoded in Yul"); ""
         }
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -253,23 +253,7 @@ object Util {
       * @return its selector hash
       */
     def hashOfFunctionDef(f: FunctionDefinition): String = {
-        // this small function is here because the parameters of a function definition are typed
-        // names, which (weirdly?) only contain the string representation of the obsidian type
-        // not the full thing.
-        //
-        // todo: refactor typed names to contain the whole type, then remove this function.
-        def hack(st: String): ObsidianType = {
-            st match {
-                case "bool" => BoolType()
-                case "int" => IntType()
-                case "string" => StringType()
-                case "Int256" => Int256Type()
-                case "unit" => UnitType()
-                case _ => assert(false); UnitType()
-            }
-        }
-
-        hashOfFunctionName(f.name, f.parameters.map(p => baseTypeToYulName(hack(p.ntype))))
+        hashOfFunctionName(f.name, f.parameters.map(p => baseTypeToYulName(p.typ)))
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -302,6 +302,20 @@ object Util {
         ct.allFields.toList.map(f => sizeOfObsType(f.typ)).sum
     }
 
+    /** given a contract table and a field name, compute the number of bytes offset from the
+      * beginning of that contract's area in memory to find the field.
+      *
+      * @param ct the contract table
+      * @param name the field to look for
+      * @return number of bytes offset
+      */
+    def offsetOfField(ct: ContractTable, name: String): Int = {
+        ct.allFields.toList
+            .takeWhile(f => f.name != name) // drop the suffix including and after the target
+            .map(f => sizeOfObsType(f.typ)) // compute the sizes of everything before the target
+            .sum // add up those sizes to get the offset
+    }
+
     /**
       * given an expression, produce the name of the contract that it associates with.
       * WARNING: this is a stub! actually implementing this means reworking the translation to yul

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -188,7 +188,7 @@ object Util {
                 case Int256Type() => "int256"
                 case UnitType() => assert(assertion = false, "unimplemented: unit type not encoded in Yul"); ""
             }
-            case t: NonPrimitiveType => t.contractName 
+            case t: NonPrimitiveType => t.contractName
             case BottomType() => assert(assertion = false, "unimplemented: bottom type not encoded in Yul"); ""
         }
     }
@@ -276,7 +276,7 @@ object Util {
             case nonPrimitiveType: NonPrimitiveType => nonPrimitiveType match {
                 case ContractReferenceType(_, _, _) => pointer_size
                 case StateType(_, _, _) =>
-                    // one day, this should probably be ceil(log_2 (length of stateNames()))) bits
+                    // todo: one day, this should probably be ceil(log_2 (length of stateNames()))) bits
                     assert(assertion = false, "size of states is unimplemented"); -1
                 case InterfaceContractType(_, _) => pointer_size
                 case GenericType(_, _) =>
@@ -334,7 +334,7 @@ object Util {
       * @param e the expression of interest
       * @return the name of the contract for the expression, if there is one; raises an error otherwise
       */
-    def getContractName(e: edu.cmu.cs.obsidian.parser.Expression): String = { //todo should this return an option? what's the invariant exactly?
+    def getContractName(e: edu.cmu.cs.obsidian.parser.Expression): String = {
         e.obstype match {
             case Some(value) => value match {
                 case _: PrimitiveType => assert(assertion = false, s"primitive types do not have contract names"); ""
@@ -377,6 +377,13 @@ object Util {
         }
     }
 
+    /** given a contract table and a name of a field, produce the expression that computes
+      * the address of that field offset into the contract
+      *
+      * @param ct the contract table
+      * @param x the field name
+      * @return the expression computing the offset
+      */
     def fieldFromThis(ct: ContractTable, x: String): Expression = {
         apply("add", Identifier("this"), intlit(Util.offsetOfField(ct, x)))
     }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -381,4 +381,8 @@ object Util {
             Some(halves(0), halves(1))
         }
     }
+
+    def fieldFromThis(ct : ContractTable, x: String): Expression = {
+        apply("add", Identifier("this"), intlit(Util.offsetOfField(ct,x)))
+    }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -299,7 +299,7 @@ object Util {
       * @return the number of bytes needed to store the fields of the contract
       */
     def sizeOfContract(ct: ContractTable): Int = {
-        ct.allFields.map(f => sizeOfObsType(f.typ)).sum
+        ct.allFields.toList.map(f => sizeOfObsType(f.typ)).sum
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -55,10 +55,6 @@ case class Case(value: Literal, body: Block) extends YulAST {
 
 case class Literal(kind: LiteralKind.LiteralKind, value: String, vtype: String) extends Expression {
     override def toString: String = {
-        /* todo/iev: i'm not positive if these assertions are the best idea, but they might be
-           a nice seatbelt. the constants i'm checking against may be wrong or incomplete right now,
-           this needs to be tested. add more complex assertions?
-        */
         val msg: String = "internal error: literal with inconsistent type string"
         kind match {
             case LiteralKind.number => assert(vtype == "int", msg)

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -3,6 +3,7 @@ package edu.cmu.cs.obsidian.codegen
 import com.github.mustachejava.DefaultMustacheFactory
 import edu.cmu.cs.obsidian.codegen
 import edu.cmu.cs.obsidian.codegen.Util._
+import edu.cmu.cs.obsidian.typecheck.{IntType, ObsidianType}
 
 import java.io.{FileReader, StringWriter}
 
@@ -21,7 +22,7 @@ trait Expression extends YulAST
 trait YulStatement extends YulAST
 
 // for each asm struct, create a case class
-case class TypedName(name: String, ntype: String) extends YulAST {
+case class TypedName(name: String, typ: ObsidianType) extends YulAST {
     override def toString: String = {
         name
 /*
@@ -393,8 +394,8 @@ case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], ch
 
             val bod: Seq[YulStatement] = assign1(Identifier("tail"), apply("add", Identifier("headStart"), intlit(32 * n))) +: encode_lines
             FunctionDefinition("abi_encode_tuple_to_fromStack" + n.toString,
-                TypedName("headStart", "") +: var_indices.map(i => TypedName("value" + i.toString, "")),
-                Seq(TypedName("tail", "")), Block(bod))
+                TypedName("headStart", IntType()) +: var_indices.map(i => TypedName("value" + i.toString, IntType())),
+                Seq(TypedName("tail", IntType())), Block(bod))
         }
 
         def abiEncodeTupleFuncs(): YulStatement = Block(abiEncodesNeeded.map(write_abi_encode).toSeq)

--- a/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
@@ -10,7 +10,7 @@ import java.io.FileInputStream
 
 class UtilTest extends JUnitSuite {
 
-    private def pullSymbolTable(file: String): SymbolTable ={
+    private def pullSymbolTable(file: String): SymbolTable = {
         var prog: Program = null
         try {
             prog = Parser.parseFileAtPath(file, new FileInputStream(file), printTokens = false)
@@ -64,7 +64,7 @@ class UtilTest extends JUnitSuite {
     private def runOffsetTest(file: String, contractName: String, fieldName: String, expectedOffset: Int): Unit = {
         val symbols = pullSymbolTable(file)
         symbols.contract(contractName) match {
-            case Some(value) => assertTrue("offset did not match expected offset", Util.offsetOfField(value,fieldName) == expectedOffset)
+            case Some(value) => assertTrue("offset did not match expected offset", Util.offsetOfField(value, fieldName) == expectedOffset)
             case None => assertTrue("type checker produced a symbol table missing a contract", false)
         }
     }
@@ -80,10 +80,10 @@ class UtilTest extends JUnitSuite {
     }
 
     @Test def offsetOfXSetGetTwoInts(): Unit = {
-        runOffsetTest("resources/tests/GanacheTests/SG.obs","IntContainer","x",0)
+        runOffsetTest("resources/tests/GanacheTests/SG.obs", "IntContainer", "x", 0)
     }
 
     @Test def offsetOfYSetGetTwoInts(): Unit = {
-        runOffsetTest("resources/tests/GanacheTests/SG.obs","IntContainer","y",32)
+        runOffsetTest("resources/tests/GanacheTests/SG.obs", "IntContainer", "y", 32)
     }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
@@ -76,7 +76,7 @@ class UtilTest extends JUnitSuite {
 
     @Test def sizeOfSetGetTwoInts(): Unit = {
         runSizeTest("resources/tests/GanacheTests/SG.obs",
-            Map("SG" -> 0, "IntContainer" -> 64))
+            Map("SG" -> 0, "IntContainer" -> 4*32))
     }
 
     @Test def offsetOfXSetGetTwoInts(): Unit = {
@@ -85,5 +85,13 @@ class UtilTest extends JUnitSuite {
 
     @Test def offsetOfYSetGetTwoInts(): Unit = {
         runOffsetTest("resources/tests/GanacheTests/SG.obs", "IntContainer", "y", 32)
+    }
+
+    @Test def offsetOfZSetGetTwoInts(): Unit = {
+        runOffsetTest("resources/tests/GanacheTests/SG.obs", "IntContainer", "z", 64)
+    }
+
+    @Test def offsetOfFSetGetTwoInts(): Unit = {
+        runOffsetTest("resources/tests/GanacheTests/SG.obs", "IntContainer", "f", 96)
     }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
@@ -62,9 +62,8 @@ class UtilTest extends JUnitSuite {
     }
 
     private def runOffsetTest(file: String, contractName: String, fieldName: String, expectedOffset: Int): Unit = {
-        val symbols = pullSymbolTable(file)
-        symbols.contract(contractName) match {
-            case Some(value) => assertTrue("offset did not match expected offset", Util.offsetOfField(value, fieldName) == expectedOffset)
+        pullSymbolTable(file).contract(contractName) match {
+            case Some(ct) => assertTrue("offset did not match expected offset", Util.offsetOfField(ct, fieldName) == expectedOffset)
             case None => assertTrue("type checker produced a symbol table missing a contract", false)
         }
     }

--- a/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
@@ -10,10 +10,7 @@ import java.io.FileInputStream
 
 class UtilTest extends JUnitSuite {
 
-    private def runTest(file: String, expectedSizes: Map[String, Int]): Unit = {
-        // every AST has a contract called "Contract" in it, so we add that to the expected sizes manually
-        val expected: Map[String, Int] = expectedSizes + ("Contract" -> 0)
-
+    private def pullSymbolTable(file: String): SymbolTable ={
         var prog: Program = null
         try {
             prog = Parser.parseFileAtPath(file, new FileInputStream(file), printTokens = false)
@@ -37,20 +34,26 @@ class UtilTest extends JUnitSuite {
             fail(s"Type checking errors: ${errs.toString}")
         }
 
+        checker.checkProgram()._2
+    }
+
+    private def runSizeTest(file: String, expectedSizes: Map[String, Int]): Unit = {
+        // every AST has a contract called "Contract" in it, so we add that to the expected sizes manually
+        val expected: Map[String, Int] = expectedSizes + ("Contract" -> 0)
+
         // stash the symbol table that we get from the type checker so that we don't have to rerun
         // checkProgram every time below
-        val symbols = checker.checkProgram()._2
+        val symbols = pullSymbolTable(file)
 
         // given a contract, return its name paired with the size of its type
         def contractPair(c: Contract): (String, Int) = {
-            val ct = symbols.contract(c.name)
-            ct match {
+            symbols.contract(c.name) match {
                 case Some(value) => (c.name, Util.sizeOfContract(value))
-                case None => assertTrue("the typechecker produced a symbol table missing contracts", false); ("", -1)
+                case None => assertTrue("the type checker produced a symbol table missing contracts", false); ("", -1)
             }
         }
 
-        // iterate over the contracts in the symboltable's AST and compute all the sizes
+        // iterate over the contracts in the symbol table's AST and compute all the sizes
         val contractSizes: Map[String, Int] = Map.from(symbols.ast.contracts.map(contractPair))
 
         // the test passes if the map of expected sizes agrees with the computed one.
@@ -58,13 +61,29 @@ class UtilTest extends JUnitSuite {
             contractSizes.equals(expected))
     }
 
+    private def runOffsetTest(file: String, contractName: String, fieldName: String, expectedOffset: Int): Unit = {
+        val symbols = pullSymbolTable(file)
+        symbols.contract(contractName) match {
+            case Some(value) => assertTrue("offset did not match expected offset", Util.offsetOfField(value,fieldName) == expectedOffset)
+            case None => assertTrue("type checker produced a symbol table missing a contract", false)
+        }
+    }
+
     @Test def sizeOfSetGetNoArgsNoConstructNoInit(): Unit = {
-        runTest("resources/tests/GanacheTests/SetGetNoArgsNoConstructNoInit.obs",
+        runSizeTest("resources/tests/GanacheTests/SetGetNoArgsNoConstructNoInit.obs",
             Map("SetGetNoArgsNoConstructNoInit" -> 0, "IntContainer" -> 32))
     }
 
     @Test def sizeOfSetGetTwoInts(): Unit = {
-        runTest("resources/tests/GanacheTests/SG.obs",
+        runSizeTest("resources/tests/GanacheTests/SG.obs",
             Map("SG" -> 0, "IntContainer" -> 64))
+    }
+
+    @Test def offsetOfXSetGetTwoInts(): Unit = {
+        runOffsetTest("resources/tests/GanacheTests/SG.obs","IntContainer","x",0)
+    }
+
+    @Test def offsetOfYSetGetTwoInts(): Unit = {
+        runOffsetTest("resources/tests/GanacheTests/SG.obs","IntContainer","y",32)
     }
 }

--- a/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
@@ -62,4 +62,9 @@ class UtilTest extends JUnitSuite {
         runTest("resources/tests/GanacheTests/SetGetNoArgsNoConstructNoInit.obs",
             Map("SetGetNoArgsNoConstructNoInit" -> 0, "IntContainer" -> 32))
     }
+
+    @Test def sizeOfSetGetTwoInts(): Unit = {
+        runTest("resources/tests/GanacheTests/SG.obs",
+            Map("SG" -> 0, "IntContainer" -> 64))
+    }
 }

--- a/travis_specific/ganache_tests.sh
+++ b/travis_specific/ganache_tests.sh
@@ -33,7 +33,7 @@ else
   tests=(resources/tests/GanacheTests/*.json)
 fi
 
-missing_json=$(diff --changed-group-format='%<%>' --unchanged-group-format='' <(ls resources/tests/GanacheTests/*.json | xargs basename -s '.json') <(ls resources/tests/GanacheTests/*.obs | xargs basename -s '.obs'))
+missing_json=$(bin/skipped_tests.sh)
 if [ "$missing_json" ]
 then
   echo "******** warning: some tests are defined but do not have json files and will not be run:"


### PR DESCRIPTION
this addresses #371 and #372. These tests pass:

- https://github.com/mcoblenz/Obsidian/blob/flat_offsets/resources/tests/GanacheTests/SG.obs
- https://github.com/mcoblenz/Obsidian/blob/flat_offsets/resources/tests/GanacheTests/SetGetNoArgsNoConstruct.obs
- https://github.com/mcoblenz/Obsidian/blob/flat_offsets/resources/tests/GanacheTests/SetGetNoArgsNoConstructNoInit.obs

These do not:

- https://github.com/mcoblenz/Obsidian/blob/flat_offsets/resources/tests/GanacheTests/SetGet.obs fails because the entry for the set function that takes an argument in the dispatch table has a free variable in it; this is documented in https://github.com/mcoblenz/Obsidian/issues/370 but I'm not quite sure how to fix it.
- https://github.com/mcoblenz/Obsidian/blob/flat_offsets/resources/tests/GanacheTests/SetGetNoArgs.obs fails because I haven't implemented constructors or constructors that take arguments (https://github.com/mcoblenz/Obsidian/issues/359)

this also addresses https://github.com/mcoblenz/Obsidian/issues/361