### PR TITLE
allocate fields with pointers, rewrite yulobject and mustache interaction to reflect current object layout

### DIFF
--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -87,9 +87,7 @@ object "{{contractName}}" {
                 cleaned := value
             }
 
-            {{#transactions}}
-                {{toString}}
-            {{/transactions}}
+            {{transactions}}
         }
     }
 }

--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -105,7 +105,5 @@ object "{{creationObject}}" {
                 {{code}}
             {{/runtimeFunctions}}
         }
-
-        {{childContracts}}
     }
 }

--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -37,7 +37,7 @@ object "{{creationObject}}" {
             if iszero(lt(calldatasize(), 4)) {
                 {{#dispatch}}
                     {{! TODO 224 is a magic number offset to shift to follow the spec above; check that it's right }}
-                    let this := address()
+                    let this := allocate_memory({{mainSize}})
                     let selector := shr(224, calldataload(0))
                     {{dispatchCase}}
                 {{/dispatch}}

--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -88,7 +88,7 @@ object "{{contractName}}" {
             }
 
             {{#transactions}}
-                {{code}}
+                {{toString}}
             {{/transactions}}
         }
     }

--- a/Obsidian_Runtime/src/main/yul_templates/object.mustache
+++ b/Obsidian_Runtime/src/main/yul_templates/object.mustache
@@ -5,42 +5,28 @@ ethereum/solidity/libsolidity/codegen/ir/IRGenerator.cpp
 Consulting example yul code is also helpful in understanding the template.
 https://solidity.readthedocs.io/en/latest/yul.html#specification-of-yul-object
 }}
-object "{{creationObject}}" {
+object "{{contractName}}" {
     code {
         {{! init free memory pointer, see chatper "Layout in Memory" of the Solidity doc}}
         {{memoryInit}}
         {{! protection against sending Ether }}
         {{callValueCheck}}
-        {{! not impletmented by the current stage, cited from IRGenerator.cpp (link in file comment above) }}
-        {{#notLibrary}}
-            {{#constructorHasParams}} let {{constructorParams}} := {{copyConstructorArguments}}() {{/constructorHasParams}}
-            {{implicitConstructor}}({{constructorParams}})
-        {{/notLibrary}}
-        {{! todo: write and call constructor }}
-        {{#deploy}}
-            {{call}}
-        {{/deploy}}
-        {{! functions related to constructor }}
-        {{#deployFunctions}}
-            {{code}}
-        {{/deployFunctions}}
         {{codeCopy}}
         {{defaultReturn}}
     }
-    object "{{runtimeObjectName}}" {
+    object "{{deployedName}}" {
         code {
             {{! init free memory pointer, see chatper "Layout in Memory" of the Solidity doc}}
-            {{memoryInitRuntime}}
+            {{memoryInit}}
+
             {{! obtain which runtime function is called, https://solidity.readthedocs.io/en/latest/abi-spec.html#function-selector}}
 
             {{! todo: is 4 a magic number or should it be generated based on the object in question? check the ABI }}
             if iszero(lt(calldatasize(), 4)) {
-                {{#dispatch}}
-                    {{! TODO 224 is a magic number offset to shift to follow the spec above; check that it's right }}
-                    let this := allocate_memory({{mainSize}})
-                    let selector := shr(224, calldataload(0))
-                    {{dispatchCase}}
-                {{/dispatch}}
+                {{! TODO 224 is a magic number offset to shift to follow the spec above; check that it's right }}
+                let this := allocate_memory({{mainSize}})
+                let selector := shr(224, calldataload(0))
+                {{dispatchTable}}
             }
             if iszero(calldatasize()) {  }
             revert(0, 0)
@@ -101,9 +87,9 @@ object "{{creationObject}}" {
                 cleaned := value
             }
 
-            {{#runtimeFunctions}}
+            {{#transactions}}
                 {{code}}
-            {{/runtimeFunctions}}
+            {{/transactions}}
         }
     }
 }

--- a/bin/run_any_yul.sh
+++ b/bin/run_any_yul.sh
@@ -39,15 +39,8 @@ then
     exit 1
 fi
 
-echo "Yul that produced the binary:"
-TOP=$(echo "$output" | grep -n "Pretty printed source:" | cut -f1 -d:)
-BOT=$(echo "$output" | grep -n "Binary representation:" | cut -f1 -d:)
-TOP=$((TOP+1)) # drop the line with the name
-BOT=$((BOT-2)) # drop the empty line after the binary
-echo -ne "$output" | sed -n $TOP','$BOT'p' | bat -l javascript --style=plain -P
-
 TOP=$(echo "$output" | grep -n "Binary representation" | cut -f1 -d:)
-BOT=$(echo "$output" | grep -n "Text representation" | cut -f1 -d:)
+BOT=$(echo "$output" | wc -l | awk '{print $1}' )
 TOP=$((TOP+1)) # drop the line with the name
 BOT=$((BOT-1)) # drop the empty line after the binary
 EVM_BIN=$(echo "$output" | sed -n $TOP','$BOT'p' )

--- a/resources/tests/GanacheTests/SetGetPointer.json
+++ b/resources/tests/GanacheTests/SetGetPointer.json
@@ -1,0 +1,8 @@
+{
+    "gas" : 30000000,
+    "gasprice" : "0x9184e72a000",
+    "startingeth" : 5000000,
+    "numaccts" : 1,
+    "testexp" : "main()",
+    "expected" : "1800"
+}

--- a/resources/tests/GanacheTests/SetGetPointer.obs
+++ b/resources/tests/GanacheTests/SetGetPointer.obs
@@ -24,7 +24,7 @@ contract IntContainer{
 // this differs from the test in SG.obs in that the main contract
 // not only has a field  but that field is at a non-primitive type
 main contract SetGetPointer {
-    IntContainer ic;
+    IntContainer@Owned ic;
 
     transaction main() returns int{
         ic = new IntContainer();

--- a/resources/tests/GanacheTests/SetGetPointer.obs
+++ b/resources/tests/GanacheTests/SetGetPointer.obs
@@ -1,0 +1,34 @@
+contract IntContainer{
+    int x;
+    int y;
+    int z;
+    int f;
+
+    transaction set() {
+        x = -1;
+        f = -1;
+        z = -1;
+        y = -1;
+        x = 5;
+        y = 10;
+        z = 4;
+        f = 9;
+    }
+
+    transaction get() returns int{
+        return x*y*z*f; // 1800
+    }
+}
+
+
+// this differs from the test in SG.obs in that the main contract
+// not only has a field  but that field is at a non-primitive type
+main contract SetGetPointer {
+    IntContainer ic;
+
+    transaction main() returns int{
+        ic = new IntContainer();
+        ic.set();
+        return ic.get();
+    }
+}

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -153,6 +153,8 @@ object CodeGenYul extends CodeGenerator {
             }
         }
 
+        // todo: i think that i can remove the inMain argument form translateStatement and translateExpression
+
         // form the body of the transaction by translating each statement found
         val body: Seq[YulStatement] = transaction.body.flatMap((s: Statement) => translateStatement(s, id, contractName, checkedTable, inMain))
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -117,6 +117,17 @@ object CodeGenYul extends CodeGenerator {
             runtimeSubobj = Seq(),
             data = Seq())
 
+        val sizeOfMain: Int = checkedTable.contract(contract.name) match {
+            case Some(ct) => Util.sizeOfContract(ct)
+            case None => assert(false, "no main contract in the symbol table"); -1
+        }
+
+        // if the main contract takes up space, we need to allocate some for it and make that
+        // available as this to any transaction in main.
+        if (sizeOfMain > 0){
+            // todo
+        }
+
         YulObject(name = contract.name,
             code = Code(Block(Seq())),
             runtimeSubobj = Seq(runtime_obj),

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -111,16 +111,9 @@ object CodeGenYul extends CodeGenerator {
       * @return the yul
       */
     def translateMainContract(contract: ObsidianContractImpl, checkedTable: SymbolTable): YulObject = {
-        var decls: Seq[YulStatement] = Seq()
-
-        // translate declarations
-        for (d <- contract.declarations) {
-            decls = decls ++ translateDeclaration(d, contract.name, checkedTable, inMain = true)
-        }
-
         // create runtime object from just the declarations and with the subobject name suffix
         val runtime_obj = YulObject(name = contract.name + "_deployed",
-            code = Code(Block(decls)),
+            code = Code(Block(contract.declarations.flatMap(d => translateDeclaration(d, contract.name, checkedTable, inMain = true)))),
             runtimeSubobj = Seq(),
             data = Seq())
 
@@ -140,15 +133,8 @@ object CodeGenYul extends CodeGenerator {
       * @return the YulObject representing the translation. note that all the fields other than `code` will be the empty sequence.
       */
     def translateNonMainContract(c: ObsidianContractImpl, checkedTable: SymbolTable): YulObject = {
-        var translation: Seq[YulStatement] = Seq()
-
-        for (d <- c.declarations) {
-            val dTranslated = translateDeclaration(d, c.name, checkedTable, inMain = false)
-            translation = translation ++ dTranslated
-        }
-
         YulObject(name = c.name,
-            code = Code(Block(translation)),
+            code = Code(Block(c.declarations.flatMap(d => translateDeclaration(d, c.name, checkedTable, inMain = false)))),
             runtimeSubobj = Seq(),
             data = Seq()
         )

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -97,7 +97,6 @@ object CodeGenYul extends CodeGenerator {
         YulObject(name = mainContractYO.name,
             code = mainContractYO.code,
             runtimeSubobj = mainContractYO.runtimeSubobj ++ childContracts,
-            childContracts = Seq(), // todo maybe delete this field entirely
             data = mainContractYO.data) // todo this is always empty, we ignore data
     }
 
@@ -123,13 +122,11 @@ object CodeGenYul extends CodeGenerator {
         val runtime_obj = YulObject(name = contract.name + "_deployed",
             code = Code(Block(decls)),
             runtimeSubobj = Seq(),
-            childContracts = Seq(),
             data = Seq())
 
         YulObject(name = contract.name,
             code = Code(Block(Seq())),
             runtimeSubobj = Seq(runtime_obj),
-            childContracts = Seq(),
             data = Seq())
     }
 
@@ -153,7 +150,6 @@ object CodeGenYul extends CodeGenerator {
         YulObject(name = c.name,
             code = Code(Block(translation)),
             runtimeSubobj = Seq(),
-            childContracts = Seq(),
             data = Seq()
         )
     }
@@ -166,7 +162,7 @@ object CodeGenYul extends CodeGenerator {
       * @param declaration  the declaration to translate
       * @param contractName the name of the contract in which the declaration appears
       * @param checkedTable the symbol table for the contract in which the declaration appears
-      * @param inMain       whether or not the contract in which the declaration apepars is the main one
+      * @param inMain       whether or not the contract in which the declaration appears is the main one
       * @return the yul statements corresponding to the declaration
       */
     def translateDeclaration(declaration: Declaration, contractName: String, checkedTable: SymbolTable, inMain: Boolean): Seq[YulStatement] = {

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -158,11 +158,13 @@ object CodeGenYul extends CodeGenerator {
         // form the body of the transaction by translating each statement found
         val body: Seq[YulStatement] = transaction.body.flatMap((s: Statement) => translateStatement(s, id, contractName, checkedTable, inMain))
 
-        // return the function definition formed from the above parts
-        FunctionDefinition(name = if (inMain) { transaction.name } else { transactionNameMapping(contractName, transaction.name) },
+        // return the function definition formed from the above parts, with an added special argument called `this` for the address
+        // of the allocated instance on which it should act
+        addThisArgument(
+            FunctionDefinition(name = if (inMain) { transaction.name } else { transactionNameMapping(contractName, transaction.name) },
             parameters = transaction.args.map(v => TypedName(v.varName, v.typIn)),
             ret,
-            body = Block(body))
+            body = Block(body)))
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -317,12 +317,24 @@ object CodeGenYul extends CodeGenerator {
             assign1(retvar, apply("or", apply(s, e1id, e2id), apply("eq", e1id, e2id)))
     }
 
-    //todo document this; it's a helper to share some code repeated between the two Invocation cases
+    /** This encapsulates a general pattern of translation shared between both local and general
+      * invocations, as called below in the two relevant cases of translate expression.
+      *
+      * @param name the name of the thing being invoked
+      * @param args the arguments to the invokee
+      * @param obstype the type at the invocation site
+      * @param thisID where to look in memory for the relevant fields
+      * @param retvar the tempory variable to store the return
+      * @param contractName the overall name of the contract being translated
+      * @param checkedTable the checked tabled for the overall contract
+      * @param inMain whether or not this is being elborated in main
+      * @return the sequence of yul statements that are the translation of the invocation so described
+      */
     def translateInvocation(name : String,
                             args: Seq[Expression],
-                            obstype: Option[ObsidianType], //the innards of an invocation
-                            thisID: Identifier, // where to look for `this`, which changes for local or general invocations
-                            retvar: Identifier, contractName: String, checkedTable: SymbolTable, inMain: Boolean // the recursive args for the rest of expansion
+                            obstype: Option[ObsidianType],
+                            thisID: Identifier,
+                            retvar: Identifier, contractName: String, checkedTable: SymbolTable, inMain: Boolean
                            ): Seq[YulStatement] ={
         // look up the name of the function in the table, get its return type, and then compute
         // how wide of a tuple that return type is. right now that's either 1 (if the

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -167,10 +167,12 @@ object CodeGenYul extends CodeGenerator {
       */
     def translateDeclaration(declaration: Declaration, contractName: String, checkedTable: SymbolTable, inMain: Boolean): Seq[YulStatement] = {
         declaration match {
-            case f: Field => Seq() // fields are translated as they are encountered
+            case _: Field => Seq() // fields are translated as they are encountered
             case t: Transaction => translateTransaction(t, contractName, checkedTable, inMain)
-            case s: State => Seq() // this is unimplemented
-            case c: ObsidianContractImpl =>
+            case _: State =>
+                assert(assertion = false, "TODO")
+                Seq()
+            case _: ObsidianContractImpl =>
                 assert(assertion = false, "TODO")
                 Seq()
             case _: JavaFFIContractImpl =>

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -143,14 +143,6 @@ object CodeGenYul extends CodeGenerator {
 
         var id: Option[Identifier] = None
 
-        // if the transaction appears in main, it keeps its name, otherwise it gets prepended with the name of the contract in which it appears.
-        val name: String =
-            if (inMain) {
-                transaction.name
-            } else {
-                transactionNameMapping(contractName, transaction.name)
-            }
-
         // translate the return type to the ABI names
         val ret: Seq[TypedName] = {
             transaction.retType match {
@@ -161,13 +153,14 @@ object CodeGenYul extends CodeGenerator {
             }
         }
 
-        val args: Seq[TypedName] = transaction.args.map(v => TypedName(v.varName, v.typIn))
-
         // form the body of the transaction by translating each statement found
         val body: Seq[YulStatement] = transaction.body.flatMap((s: Statement) => translateStatement(s, id, contractName, checkedTable, inMain))
 
         // return the function definition formed from the above parts
-        FunctionDefinition(name, args, ret, Block(body))
+        FunctionDefinition(name = if (inMain) { transaction.name } else { transactionNameMapping(contractName, transaction.name) },
+            parameters = transaction.args.map(v => TypedName(v.varName, v.typIn)),
+            ret,
+            body = Block(body))
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -387,4 +387,9 @@ object Util {
     def fieldFromThis(ct: ContractTable, x: String): Expression = {
         apply("add", Identifier("this"), intlit(Util.offsetOfField(ct, x)))
     }
+
+    def addThisArgument(f : FunctionDefinition) : FunctionDefinition = {
+        FunctionDefinition(f.name, f.parameters, f.returnVariables, f.body)
+    }
+
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -253,7 +253,7 @@ object Util {
       * @return its selector hash
       */
     def hashOfFunctionDef(f: FunctionDefinition): String = {
-        hashOfFunctionName(f.name, f.parameters.map(p => baseTypeToYulName(p.typ)))
+            hashOfFunctionName(f.name, f.parameters.map(p => baseTypeToYulName(p.typ)))
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/Util.scala
@@ -389,12 +389,24 @@ object Util {
     }
 
     /** given a function, return the function with an added `this` argument
-      * @param f
+      * @param f //todo
       * @return
       */
     def addThisArgument(f : FunctionDefinition) : FunctionDefinition = {
         // todo: string type is a temporary hack here
         FunctionDefinition(f.name, Seq(TypedName("this", StringType())) ++ f.parameters, f.returnVariables, f.body)
+    }
+
+    /** given a function, return the function without the added `this` argument
+      * @param f //todo
+      * @return
+      */
+    def dropThisArgument(f : FunctionDefinition) : FunctionDefinition = {
+        f.parameters match {
+            case TypedName("this", StringType()) :: tl => FunctionDefinition(f.name, tl, f.returnVariables, f.body)
+            case _ :: _ => throw new RuntimeException("dropping `this` argument from a sequence of args that doesn't start with `this`")
+            case _ => throw new RuntimeException("dropping argument from empty list")
+        }
     }
 
     /**

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -208,6 +208,7 @@ case class HexLiteral(content: String) extends YulAST
 
 case class StringLiteral(content: String) extends YulAST
 
+// todo document this class now
 case class YulObject(contractName : String,
                      data: Seq[Data],
                      mainContractTransactions: Seq[YulStatement],
@@ -297,10 +298,7 @@ case class YulObject(contractName : String,
             )
         }
 
-        // todo: this seems like a weird place for the this argument to finally get added, but maybe it's right?
-        //    at least for the transactions from the main contract we need to know their signatures without it so
-        //    that we can put the right thing in the dispatch table
-        def transactions(): YulStatement = Block((mainContractTransactions ++ otherTransactions).map(t => addThisArgument(t.asInstanceOf[FunctionDefinition])))
+        // todo: there are some instanceOf things here that always work but i am not in love with them. talk to MC about it
 
         // the dispatch table gets one entry for each transaction in the main contract. the transactions
         // elaborations are added below, and those have a `this` argument added, which is supplied in the
@@ -318,10 +316,9 @@ case class YulObject(contractName : String,
                                                         .map(write_abi_encode)
                                                         .toSeq)
 
-        class Func(val code: String) {}
-
-        class Case(val hash: String) {}
-
-        class Call(val call: String) {}
+        // todo: this seems like a weird place for the this argument to finally get added, but maybe it's right?
+        //    at least for the transactions from the main contract we need to know their signatures without it so
+        //    that we can put the right thing in the dispatch table
+        def transactions(): YulStatement = Block((mainContractTransactions ++ otherTransactions).map(t => addThisArgument(t.asInstanceOf[FunctionDefinition])))
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -208,7 +208,7 @@ case class HexLiteral(content: String) extends YulAST
 
 case class StringLiteral(content: String) extends YulAST
 
-case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], childContracts: Seq[YulObject], data: Seq[Data]) extends YulAST {
+case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], data: Seq[Data]) extends YulAST {
     def yulString(): String = {
         val mf = new DefaultMustacheFactory()
         val mustache = mf.compile(new FileReader("Obsidian_Runtime/src/main/yul_templates/object.mustache"), "example")
@@ -341,9 +341,6 @@ case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], ch
                 }
             }
         }
-
-        // recursively compute the strings for the child contracts
-        def childContracts: String = obj.childContracts.foldRight("") { (o, str) => o.yulString() + str }
 
         def dispatchCase(): codegen.Switch = codegen.Switch(Identifier("selector"), dispatchArray.toSeq)
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -25,25 +25,25 @@ trait YulStatement extends YulAST
 case class TypedName(name: String, typ: ObsidianType) extends YulAST {
     override def toString: String = {
         name
-/*
-ideally we'd want to do something like this:
+        /*
+        ideally we'd want to do something like this:
 
-        s"$name ${
-            if (ntype.isEmpty) {
-                ""
-            } else {
-                s" : $ntype"
-            }
-        }"
+                s"$name ${
+                    if (ntype.isEmpty) {
+                        ""
+                    } else {
+                        s" : $ntype"
+                    }
+                }"
 
-but as of Sept2021, solc does not support that output even though it's in the def, e.g.
+        but as of Sept2021, solc does not support that output even though it's in the def, e.g.
 
-Error: "string" is not a valid type (user defined types are not yet supported).
-   --> /sources/SetGetNoArgsNoConstructNoInit.yul:144:29:
-    |
-144 | function IntContainer___get(this  : string) -> _ret_2 {
-    |                             ^^^^^^^^^^^^^^
-*/
+        Error: "string" is not a valid type (user defined types are not yet supported).
+           --> /sources/SetGetNoArgsNoConstructNoInit.yul:144:29:
+            |
+        144 | function IntContainer___get(this  : string) -> _ret_2 {
+            |                             ^^^^^^^^^^^^^^
+        */
     }
 }
 
@@ -209,11 +209,11 @@ case class HexLiteral(content: String) extends YulAST
 case class StringLiteral(content: String) extends YulAST
 
 // todo document this class now
-case class YulObject(contractName : String,
+case class YulObject(contractName: String,
                      data: Seq[Data],
                      mainContractTransactions: Seq[YulStatement],
                      mainContractSize: Int,
-                     otherTransactions: Seq[YulStatement]) extends YulAST{
+                     otherTransactions: Seq[YulStatement]) extends YulAST {
     def yulString(): String = {
         val mf = new DefaultMustacheFactory()
         val mustache = mf.compile(new FileReader("Obsidian_Runtime/src/main/yul_templates/object.mustache"), "example")
@@ -232,7 +232,7 @@ case class YulObject(contractName : String,
     class YulMustache(obj: YulObject) {
         // the values here are defined, as much as possible, in the same order as the mustache file
         val contractName: String = obj.contractName
-        val deployedName : String = obj.contractName + "_deployed"
+        val deployedName: String = obj.contractName + "_deployed"
 
         val freeMemPointer = 64 // 0x40: currently allocated memory size (aka. free memory pointer)
         val firstFreeMem = 128 //  0x80: first byte in memory not reserved for special usages
@@ -308,13 +308,13 @@ case class YulObject(contractName : String,
         def dispatchTable(): codegen.Switch =
             codegen.Switch(Identifier("selector"),
                 mainContractTransactions.map(t => codegen.Case(hexlit(hashOfFunctionDef(t.asInstanceOf[FunctionDefinition])),
-                                                                Block(dispatchEntry(addThisArgument(t.asInstanceOf[FunctionDefinition]))))))
+                    Block(dispatchEntry(addThisArgument(t.asInstanceOf[FunctionDefinition]))))))
 
         def abiEncodeTupleFuncs(): YulStatement = Block((mainContractTransactions ++ otherTransactions)
-                                                        .map(t => t.asInstanceOf[FunctionDefinition].returnVariables.length)
-                                                        .toSet
-                                                        .map(write_abi_encode)
-                                                        .toSeq)
+            .map(t => t.asInstanceOf[FunctionDefinition].returnVariables.length)
+            .toSet
+            .map(write_abi_encode)
+            .toSeq)
 
         // todo: this seems like a weird place for the this argument to finally get added, but maybe it's right?
         //    at least for the transactions from the main contract we need to know their signatures without it so

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -155,9 +155,13 @@ case class If(condition: Expression, body: Block) extends YulStatement {
 
 case class Switch(expression: Expression, cases: Seq[Case]) extends YulStatement {
     override def toString: String = {
-        s"switch ${expression.toString}" + "\n" +
-            (if (cases.isEmpty) brace("") else cases.map(c => c.toString).mkString("\n")) +
-            "\n"
+        if (cases.nonEmpty){
+            s"switch ${expression.toString}" + "\n" +
+                cases.map(c => c.toString).mkString("\n") +
+                "\n"
+        } else {
+            ""
+        }
     }
 }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -311,8 +311,8 @@ case class YulObject(contractName: String,
         // result from the transaction definitions WITHOUT the `this` argument.
         def dispatchTable(): codegen.Switch =
             codegen.Switch(Identifier("selector"),
-                mainContractTransactions.map(t => codegen.Case(hexlit(hashOfFunctionDef(t.asInstanceOf[FunctionDefinition])),
-                    Block(dispatchEntry(addThisArgument(t.asInstanceOf[FunctionDefinition]))))))
+                mainContractTransactions.map(t => codegen.Case(hexlit(hashOfFunctionDef(dropThisArgument(t.asInstanceOf[FunctionDefinition]))),
+                    Block(dispatchEntry(t.asInstanceOf[FunctionDefinition])))))
 
         def abiEncodeTupleFuncs(): YulStatement = Block((mainContractTransactions ++ otherTransactions)
             .map(t => t.asInstanceOf[FunctionDefinition].returnVariables.length)
@@ -323,6 +323,6 @@ case class YulObject(contractName: String,
         // todo: this seems like a weird place for the this argument to finally get added, but maybe it's right?
         //    at least for the transactions from the main contract we need to know their signatures without it so
         //    that we can put the right thing in the dispatch table
-        def transactions(): YulStatement = Block((mainContractTransactions ++ otherTransactions).map(t => addThisArgument(t.asInstanceOf[FunctionDefinition])))
+        def transactions(): YulStatement = Block(mainContractTransactions ++ otherTransactions)
     }
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -399,5 +399,4 @@ case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], da
 
         class Call(val call: String) {}
     }
-
 }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -312,23 +312,6 @@ case class YulObject(name: String, code: Code, runtimeSubobj: Seq[YulObject], da
 
         def deployFunctions(): Array[Func] = deployFunctionArray
 
-        for (s <- obj.code.block.statements) {
-            s match {
-                case f: FunctionDefinition =>
-                    deployFunctionArray = deployFunctionArray :+ new Func(f.toString)
-                case e: ExpressionStatement =>
-                    e.expression match {
-                        case f: FunctionCall => deployCall = deployCall :+ new Call(f.toString)
-                        case _ =>
-                            assert(assertion = false, "TODO: objscope not implemented for expression statement " + e.toString)
-                            () // TODO unimplemented
-                    }
-                case _ =>
-                    assert(assertion = false, "TODO: objscope not implemented for statement " + s.toString)
-                    () // TODO unimplemented
-            }
-        }
-
         def runtimeFunctions(): Array[Func] = runtimeFunctionArray
 
         var abiEncodesNeeded: Set[Int] = Set()

--- a/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
+++ b/src/test/scala/edu/cmu/cs/obsidian/codegen/UtilTest.scala
@@ -93,4 +93,9 @@ class UtilTest extends JUnitSuite {
     @Test def offsetOfFSetGetTwoInts(): Unit = {
         runOffsetTest("resources/tests/GanacheTests/SG.obs", "IntContainer", "f", 96)
     }
+
+    @Test def sizeOfIntContainerField(): Unit = {
+        runSizeTest("resources/tests/GanacheTests/SetGetPointer.obs",
+            Map("SetGetPointer" -> 32, "IntContainer" -> 4*32))
+    }
 }


### PR DESCRIPTION
This closes #393, #392, #391, and #389. It partially addresses #370; I think that everything in the main contract will end up in the dispatch table now, even if it's private.

One worry is that the code in `YulObject` assumes that the `Seq[YulStatement]` passed contains only function declaration objects -- this is made explicit by a use of `.asInstaceOf`. That happens to be true right now, but won't be forever I think. I'm OK with this bit of technical debt for now, but, @mcoblenz, you may not be. 

Once this is approved and merged into `flat_alloc`, I'll do a merge into master as well because I think this is a stand alone feature update as well as being on the way to allocation.