### PR TITLE
call tracers after every constructor call

### DIFF
--- a/resources/tests/GanacheTests/SetGetConstructorField.obs
+++ b/resources/tests/GanacheTests/SetGetConstructorField.obs
@@ -21,8 +21,7 @@ main contract SetGetConstructorField{
     }
 
     transaction main() returns int{
-        //this makes yul that has a free variable in it; whose fault is that?
-        //SetGetConstructorField dummy = new SetGetConstructorField();
+        SetGetConstructorField local = new SetGetConstructorField();
         ic.set(12);
         return (ic.get());
     }

--- a/resources/tests/GanacheTests/SetGetConstructorField.obs
+++ b/resources/tests/GanacheTests/SetGetConstructorField.obs
@@ -1,0 +1,24 @@
+contract IntContainer{
+    int x;
+
+    IntContainer@Owned(int init) {
+        x = init;
+    }
+
+    transaction set(int value) {
+        x = value;
+    }
+    transaction get() returns int{
+        return x;
+    }
+}
+
+main contract SetGetConstructorField{
+    IncContainer ic;
+
+    transaction main() returns int{
+        ic = new IntContainer(5);
+        ic.set(12);
+        return (ic.get());
+    }
+}

--- a/resources/tests/GanacheTests/SetGetConstructorField.obs
+++ b/resources/tests/GanacheTests/SetGetConstructorField.obs
@@ -14,10 +14,15 @@ contract IntContainer{
 }
 
 main contract SetGetConstructorField{
-    IncContainer ic;
+    IntContainer@Owned ic;
+
+    SetGetConstructorField@Owned(){
+        ic = new IntContainer(5);
+    }
 
     transaction main() returns int{
-        ic = new IntContainer(5);
+        //this makes yul that has a free variable in it; whose fault is that?
+        //SetGetConstructorField dummy = new SetGetConstructorField();
         ic.set(12);
         return (ic.get());
     }

--- a/resources/tests/GanacheTests/tests.json
+++ b/resources/tests/GanacheTests/tests.json
@@ -262,6 +262,13 @@
             "trans" : "main_sgl",
             "logged" : [320,320,320,320],
             "shows_that_we_support": "simple set-get with tracers that emit logged values"
+        },
+        {
+            "file": "SetGetConstructorField.obs",
+            "expected": "15",
+            "trans" : "main",
+            "logged" : [320,320,320,320],
+            "shows_that_we_support": "simple set-get with tracers that emit logged values"
         }
     ]
 }

--- a/resources/tests/GanacheTests/tests.json
+++ b/resources/tests/GanacheTests/tests.json
@@ -265,10 +265,9 @@
         },
         {
             "file": "SetGetConstructorField.obs",
-            "expected": "15",
+            "expected": "12",
             "trans" : "main",
-            "logged" : [320,320,320,320],
-            "shows_that_we_support": "simple set-get with tracers that emit logged values"
+            "shows_that_we_support": "set-get with a field so that the emitted tracer is not trivial, and that uses the constructor for that field "
         }
     ]
 }

--- a/resources/tests/GanacheTests/tests.json
+++ b/resources/tests/GanacheTests/tests.json
@@ -267,6 +267,7 @@
             "file": "SetGetConstructorField.obs",
             "expected": "12",
             "trans" : "main",
+            "logged" : [224, 224, 224],
             "shows_that_we_support": "set-get with a field so that the emitted tracer is not trivial, and that uses the constructor for that field "
         }
     ]

--- a/resources/tests/GanacheTests/tests.json
+++ b/resources/tests/GanacheTests/tests.json
@@ -260,8 +260,8 @@
             "file": "SetGetLogs.obs",
             "expected": "15",
             "trans" : "main_sgl",
-            "logged" : [320,320,320,320],
-            "shows_that_we_support": "simple set-get with tracers that emit logged values"
+            "logged" : [256, 288, 320],
+            "shows_that_we_support": "simple set-get with tracers that emit values to the logs. this shows that the harness can read logs; the values logged are immaterial"
         },
         {
             "file": "SetGetConstructorField.obs",

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -135,11 +135,10 @@ object CodeGenYul extends CodeGenerator {
                                 others = others ++ writeTracers(ct, contractType.contractName)
                             case _ => Seq()
                         }
-                        case _: PrimitiveType => {
+                        case _: PrimitiveType =>
                             body = body :+
                                 //sstore(add(this,offset), mload(add(this,offset)))
                                 ExpressionStatement(apply("sstore", loc, apply("mload", loc)))
-                        }
                         case _ => Seq()
                     }
                 case _ => Seq()

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -111,7 +111,7 @@ object CodeGenYul extends CodeGenerator {
         s"trace_$name"
     }
 
-    def writeTracers(ct : SymbolTable, name: String): Seq[FunctionDefinition] = {
+    def writeTracers(ct: SymbolTable, name: String): Seq[FunctionDefinition] = {
         val c: Contract = ct.contract(name) match {
             case Some(value) => value.contract
             case None => throw new RuntimeException()
@@ -120,12 +120,12 @@ object CodeGenYul extends CodeGenerator {
         var body: Seq[YulStatement] = Seq()
         var others: Seq[FunctionDefinition] = Seq()
 
-        for(d <- c.declarations){
+        for (d <- c.declarations) {
             d match {
                 case Field(_, typ, fname, _) => typ match {
-                    case t : NonPrimitiveType => t match {
+                    case t: NonPrimitiveType => t match {
                         case ContractReferenceType(contractType, _, _) =>
-                            body = body :+ ExpressionStatement(apply(nameTracer(contractType.contractName), fieldFromThis(ct.contractLookup(name),fname)))
+                            body = body :+ ExpressionStatement(apply(nameTracer(contractType.contractName), fieldFromThis(ct.contractLookup(name), fname)))
                             others = others ++ writeTracers(ct, contractType.contractName)
                         case _ => Seq()
                     }
@@ -136,11 +136,11 @@ object CodeGenYul extends CodeGenerator {
         }
 
         FunctionDefinition(name = nameTracer(name),
-                            parameters = Seq(TypedName("this",YATAddress())),
-                            returnVariables = Seq(),
-                            body = Block(Seq(
-                                            ExpressionStatement(apply("log0",intlit(64),intlit(32)))
-                                            ) ++ body :+ Leave())
+            parameters = Seq(TypedName("this", YATAddress())),
+            returnVariables = Seq(),
+            body = Block(Seq(
+                ExpressionStatement(apply("log0", intlit(64), intlit(32)))
+            ) ++ body :+ Leave())
         ) +: others.distinctBy(fd => fd.name)
     }
 

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -572,7 +572,7 @@ object CodeGenYul extends CodeGenerator {
                     decl_1exp(id_memaddr, apply("allocate_memory", intlit(sizeOfContractST(contractType.contractName, checkedTable)))),
 
                     // return the address that the space starts at
-                    assign1(retvar, id_memaddr)) ++ conCall
+                    assign1(retvar, id_memaddr)) ++ conCall :+ ExpressionStatement(apply(nameTracer(contractType.contractName), Identifier("this")))
 
 
             case StateInitializer(stateName, fieldName, obstype) =>

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -88,7 +88,7 @@ object CodeGenYul extends CodeGenerator {
                     if (!c.modifiers.contains(IsMain())) {
                         c.declarations.flatMap(d => translateDeclaration(d, c.name, checkedTable, inMain = false))
                     } else {
-                        // skip the main and the self real_contracts
+                        // skip the main contract
                         Seq()
                     }
                 case _: JavaFFIContractImpl =>
@@ -182,7 +182,7 @@ object CodeGenYul extends CodeGenerator {
                 assert(assertion = false, "TODO")
                 Seq()
             case _: JavaFFIContractImpl =>
-                assert(assertion = false, "Java real_contracts not supported in Yul translation")
+                assert(assertion = false, "Java contracts not supported in Yul translation")
                 Seq()
             case c: Constructor =>
                 // given an obsidian type, pull out the non-primitive type or raise an exception
@@ -536,7 +536,7 @@ object CodeGenYul extends CodeGenerator {
                 (decl_0exp(id_recipient) +: recipient_yul) ++
                     // todo: this may be the cause of a bug in the future. this is how non-main
                     //  functions get their names translated before calling, but that might not
-                    //  work with multiple real_contracts and private transactions. i'm not sure.
+                    //  work with multiple contracts and private transactions. i'm not sure.
                     translateInvocation(transactionNameMapping(getContractName(recipient), name),
                         args,
                         obstype,

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -554,12 +554,20 @@ object CodeGenYul extends CodeGenerator {
                         case _ => false
                     }
 
+                // the constructor(s) for the main contract are not prefixed with the name of the contract.
+                val invoke_name =
+                    if(checkedTable.contractLookup(contractType.contractName).contract.isMain) {
+                        contractType.contractName + hashOfFunctionName(contractType.contractName, typeNames)
+                    } else {
+                        transactionNameMapping(contractType.contractName, contractType.contractName) + hashOfFunctionName(contractType.contractName, typeNames)
+                    }
+
                 // check to to see if there is a constructor to call, and if so translate the
                 // arguments and invoke the constructor as normal transaction with the hash appended
                 // to the name to call the right one
                 val conCall =
                 if (checkedTable.contract(contractType.contractName).get.contract.declarations.exists(d => isMatchingConstructor(d))) {
-                    translateInvocation(name = transactionNameMapping(contractType.contractName, contractType.contractName) + hashOfFunctionName(contractType.contractName, typeNames),
+                    translateInvocation(name = invoke_name,
                         args = args,
                         obstype = Some(UnitType()),
                         thisID = id_memaddr,

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/yulAST.scala
@@ -337,17 +337,6 @@ case class YulObject(contractName: String,
 
             val mp_id: Identifier = Identifier("memPos")
 
-            // this is a hack to get the tracer to be run on the main call of the specific test that
-            // is in SetGetLogs.
-            // todo remove this once tracers get called on-demand
-            // todo this is a way to make exactly one test work but produces bizarre output on anything else
-            val maybe_trace : YulStatement =
-                if(f.name == "main_sgl") {
-                    ExpressionStatement(apply("trace_SetGetLogs", Identifier("this")))
-                } else {
-                    LineComment("do not trace")
-                }
-
             Seq(
                 LineComment(s"entry for ${f.name}"),
                 //    if callvalue() { revert(0, 0) }
@@ -363,7 +352,6 @@ case class YulObject(contractName: String,
                 // nb: the code for these is written dynamically below so we can assume that they exist before they do
                 decl_1exp(Identifier("memEnd"), apply(abi_encode_name(returns_from_call.length), mp_id +: returns_from_call: _*)),
                 //    return(memPos, sub(memEnd, memPos))
-                maybe_trace,
                 codegen.ExpressionStatement(apply("return", mp_id, apply("sub", Identifier("memEnd"), mp_id)))
             )
         }


### PR DESCRIPTION
- we now emit a tracer for every contract in the program, not just the ones that happen to be used in fields in the main contract
- we call the tracer for a contract after it's constructed
- the tracers copy the fields to storage, for now at the same address that they appear in memory
- the tracers emit logs as they do this, but the values emitted are not that meaningful

upcoming changes not included in this PR:
- write meaningful values to the logs
- use those logged values to verify that fields are being written to storage
- write to addresses in storage that are above some thresh hold value, so we can tell which addresses are in memory and which are in storage.