### PR TITLE
log contents of fields as written to storage after constructor calls

### DIFF
--- a/resources/tests/GanacheTests/tests.json
+++ b/resources/tests/GanacheTests/tests.json
@@ -260,14 +260,14 @@
             "file": "SetGetLogs.obs",
             "expected": "15",
             "trans" : "main_sgl",
-            "logged" : [256, 288, 320],
+            "logged" : [0, 224, 224],
             "shows_that_we_support": "simple set-get with tracers that emit values to the logs. this shows that the harness can read logs; the values logged are immaterial"
         },
         {
             "file": "SetGetConstructorField.obs",
             "expected": "12",
             "trans" : "main",
-            "logged" : [224, 224, 224],
+            "logged" : [0,0,0],
             "shows_that_we_support": "set-get with a field so that the emitted tracer is not trivial, and that uses the constructor for that field "
         }
     ]

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -163,8 +163,8 @@ object CodeGenYul extends CodeGenerator {
                             case _ => Seq()
                         }
                         case _: PrimitiveType =>
-                        case _ => Seq()
                             body = body ++ load ++ log
+                        case _ => Seq()
                     }
                 case _ => Seq()
             }

--- a/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
+++ b/src/main/scala/edu/cmu/cs/obsidian/codegen/CodeGenYul.scala
@@ -131,7 +131,6 @@ object CodeGenYul extends CodeGenerator {
                         LineComment("loading"),
                         ExpressionStatement(apply("sstore", loc, apply("mload", loc))),
 
-                        // todo: refactor this so that it appears in both branches. figure out why it emits zero
                         LineComment("logging"),
                         // allocate memory to log from
                         decl_1exp(log_temp, apply("allocate_memory", intlit(32))),
@@ -143,7 +142,6 @@ object CodeGenYul extends CodeGenerator {
                     typ match {
                         case t: NonPrimitiveType => t match {
                             case ContractReferenceType(contractType, _, _) =>
-                                val logtemp = nextTemp()
                                 body = body ++ load_and_log ++
                                     Seq(
                                         LineComment("traversal"),
@@ -165,9 +163,7 @@ object CodeGenYul extends CodeGenerator {
         FunctionDefinition(name = nameTracer(name),
             parameters = Seq(TypedName("this", YATAddress())),
             returnVariables = Seq(),
-            body = Block(Seq(
-                //ExpressionStatement(apply("log0", intlit(64), intlit(32)))
-            ) ++ body :+ Leave())
+            body = Block(body :+ Leave())
         ) +: others.distinctBy(fd => fd.name)
     }
 


### PR DESCRIPTION
In the test `SetGetLogs`, we emit tracers for both contracts but the code only contains calls to the constructor for `IntContainer`. That happens three times, so we expect three things to be written to the log. At the time that the constructor is called, the field has not been initialized so I would expect those three things to all be `0`. However, we emit `0,224,224` not `0,0,0`.  I don't know where the number `224` is coming from and I'm not sure if it's right or not.

The test `SetGetConstructorField` emits `0,0,0` to the logs. This seems like the right output behaviour because the tracers are getting called only after constructor applications, which again means that the fields should be unset and cold reads to unset addresses should produce `0`. We get them three times even though there are only two uses of constructors because the tracer for the main contract recursively calls the tracer for the `IntContainer` contract before that tracer gets called again after the constructor call for it.